### PR TITLE
feature: allow "reversed" nullable schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ The following union types are accepted: `map[string]interface{}`, `*T` and `inte
 When a non-`nil` union value is encountered, a single key is en/decoded. The key is the avro
 type name, or scheam full name in the case of a named schema (enum, fixed or record).
 * ***T:** This is allowed in a "nullable" union. A nullable union is defined as a two schema union, 
-with the first being `null` (ie. `["null", "string"]`), in this case a `*T` is allowed, 
-with `T` matching the conversion table above.
+with one of the types being `null` (ie. `["null", "string"]` or `["string", "null"]`), in this case 
+a `*T` is allowed, with `T` matching the conversion table above.
 * **interface{}:** An `interface` can be provided and the type or name resolved. Primitive types
 are pre-registered, but named types, maps and slices will need to be registered with the `Register` function. In the 
 case of arrays and maps the enclosed schema type or name is postfix to the type

--- a/decoder_union_test.go
+++ b/decoder_union_test.go
@@ -105,6 +105,21 @@ func TestDecoder_UnionPtr(t *testing.T) {
 	assert.Equal(t, &want, got)
 }
 
+func TestDecoder_UnionPtrReversed(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x00, 0x06, 0x66, 0x6F, 0x6F}
+	schema := `["string", "null"]`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got *string
+	err := dec.Decode(&got)
+
+	want := "foo"
+	assert.NoError(t, err)
+	assert.Equal(t, &want, got)
+}
+
 func TestDecoder_UnionPtrReuseInstance(t *testing.T) {
 	defer ConfigTeardown()
 
@@ -128,6 +143,20 @@ func TestDecoder_UnionPtrNull(t *testing.T) {
 
 	data := []byte{0x00}
 	schema := `["null", "string"]`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got *string
+	err := dec.Decode(&got)
+
+	assert.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestDecoder_UnionPtrReversedNull(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x02}
+	schema := `["string", "null"]`
 	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
 
 	var got *string

--- a/encoder_union_test.go
+++ b/encoder_union_test.go
@@ -105,6 +105,21 @@ func TestEncoder_UnionPtr(t *testing.T) {
 	assert.Equal(t, []byte{0x02, 0x06, 0x66, 0x6F, 0x6F}, buf.Bytes())
 }
 
+func TestEncoder_UnionPtrReversed(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["string", "null"]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	assert.NoError(t, err)
+
+	str := "foo"
+	err = enc.Encode(&str)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x00, 0x06, 0x66, 0x6F, 0x6F}, buf.Bytes())
+}
+
 func TestEncoder_UnionPtrNull(t *testing.T) {
 	defer ConfigTeardown()
 
@@ -118,6 +133,21 @@ func TestEncoder_UnionPtrNull(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, []byte{0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionPtrReversedNull(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["string", "null"]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	assert.NoError(t, err)
+
+	var str *string
+	err = enc.Encode(str)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x02}, buf.Bytes())
 }
 
 func TestEncoder_UnionPtrNotNullable(t *testing.T) {

--- a/schema.go
+++ b/schema.go
@@ -656,11 +656,24 @@ func (s *UnionSchema) Types() Schemas {
 
 // Nullable returns the Schema if the union is nullable, otherwise nil.
 func (s *UnionSchema) Nullable() bool {
-	if len(s.types) != 2 || s.types[0].Type() != Null {
+	if len(s.types) != 2 || s.types[0].Type() != Null && s.types[1].Type() != Null {
 		return false
 	}
 
 	return true
+}
+
+// Indices returns the index of the null and type schemas for a
+// nullable schema. For non-nullable schemas 0 is returned for
+// both.
+func (s *UnionSchema) Indices() (null int, typ int) {
+	if !s.Nullable() {
+		return 0, 0
+	}
+	if s.types[0].Type() == Null {
+		return 0, 1
+	}
+	return 1, 0
 }
 
 // String returns the canonical form of the schema.

--- a/schema_test.go
+++ b/schema_test.go
@@ -694,6 +694,41 @@ func TestUnionSchema(t *testing.T) {
 	}
 }
 
+func TestUnionSchema_Indices(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		want   [2]int
+	}{
+		{
+			name:   "Null First",
+			schema: `["null", "string"]`,
+			want:   [2]int{0, 1},
+		},
+		{
+			name:   "Null Second",
+			schema: `["string", "null"]`,
+			want:   [2]int{1, 0},
+		},
+		{
+			name:   "Not Nullable",
+			schema: `["null", "string", "int"]`,
+			want:   [2]int{0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := avro.Parse(tt.schema)
+
+			assert.NoError(t, err)
+			null, typ := s.(*avro.UnionSchema).Indices()
+			assert.Equal(t, tt.want[0], null)
+			assert.Equal(t, tt.want[1], typ)
+		})
+	}
+}
+
 func TestFixedSchema(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
There is no particular reason not to allow `["string", "null"]` to be seen as nullable and use `*string`. It was an initial design decision that no longer holds muster. Allowing this will reduce the amount of interface casting needed when users do not control the schema.

Fixes #45