### PR TITLE
Register a boolean type

### DIFF
--- a/decoder_union_test.go
+++ b/decoder_union_test.go
@@ -242,6 +242,20 @@ func TestDecoder_UnionInterfaceInMap(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"foo": 27}, got)
 }
 
+func TestDecoder_UnionInterfaceInMapWithBool(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x01, 0x0c, 0x06, 0x66, 0x6F, 0x6F, 0x02, 0x01, 0x00}
+	schema := `{"type":"map", "values": ["null", "boolean"]}`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got map[string]interface{}
+	err := dec.Decode(&got)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"foo": true}, got)
+}
+
 func TestDecoder_UnionInterfaceMap(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/encoder_union_test.go
+++ b/encoder_union_test.go
@@ -230,6 +230,20 @@ func TestEncoder_UnionInterfaceMap(t *testing.T) {
 	assert.Equal(t, []byte{0x02, 0x01, 0x0a, 0x06, 0x66, 0x6f, 0x6f, 0x36, 0x00}, buf.Bytes())
 }
 
+func TestEncoder_UnionInterfaceInMapWithBool(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"map", "values": ["null", "boolean"]}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	assert.NoError(t, err)
+
+	err = enc.Encode(map[string]interface{}{"foo": true})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x0c, 0x06, 0x66, 0x6F, 0x6F, 0x02, 0x01, 0x00}, buf.Bytes())
+}
+
 func TestEncoder_UnionInterfaceArray(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/resolver.go
+++ b/resolver.go
@@ -32,6 +32,7 @@ func NewTypeResolver() *TypeResolver {
 	r.Register(string(Double), float64(0))
 	r.Register(string(String), "")
 	r.Register(string(Bytes), []byte{})
+	r.Register(string(Boolean), bool(true))
 
 	return r
 }


### PR DESCRIPTION
This commit fixes the following error that occurs with a map including a boolean type in unions.

```go
package main

import (
	"bytes"
	"encoding/json"
	"log"

	"github.com/hamba/avro"
)

var Schema = `{
		"type": "record",
		"name": "simple",
		"namespace": "org.hamba.avro",
		"fields" : [
			{
				"name": "properties",
				"type": {
					"type": "map",
					"values": ["null", "boolean"]
				}
			}
		]
	}`

type SimpleRecord struct {
	Properties map[string]interface{} `avro:"properties"`
}

func main() {
	schema, err := avro.Parse(Schema)
	if err != nil {
		log.Fatal(err)
	}

	data := []byte(`
	{
		"properties": {
			"bool": true
		}
	}
	`)

	in := SimpleRecord{}

	buffer := bytes.NewReader(data)
	decoder := json.NewDecoder(buffer)

	err = decoder.Decode(&in)
	if err != nil {
		log.Fatal(err)
	}

	_, err = avro.Marshal(schema, in)
	if err != nil {
		log.Fatal(err)
	}
}

```

error

```
2020/07/20 18:21:14 Properties: map[string]interface {}: avro: unable to resolve type bool
```