### PR TITLE
avro: fix map encoding with more than blocklength keys

### DIFF
--- a/codec_map.go
+++ b/codec_map.go
@@ -94,7 +94,7 @@ func (e *mapEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 	for {
 		wrote := w.WriteBlockCB(func(w *Writer) int64 {
 			var i int
-			for i = 0; iter.HasNext() || i > blockLength; i++ {
+			for i = 0; iter.HasNext() && i < blockLength; i++ {
 				keyPtr, elemPtr := iter.UnsafeNext()
 				w.WriteString(*((*string)(keyPtr)))
 				e.encoder.Encode(elemPtr, w)

--- a/encoder_map_test.go
+++ b/encoder_map_test.go
@@ -88,3 +88,27 @@ func TestEncoder_MapError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestEncoder_MapWithMoreThanBlockLengthKeys(t *testing.T) {
+	avro.DefaultConfig = avro.Config{
+		TagKey:               "avro",
+		BlockLength:          1,
+		UnionResolutionError: true,
+	}.Freeze()
+
+	schema := `{"type":"map", "values": "int"}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	assert.NoError(t, err)
+
+	err = enc.Encode(map[string]int{"foo": 1, "bar": 2})
+
+	assert.NoError(t, err)
+	assert.Condition(t, func() bool {
+		// {"foo": 1, "bar": 2}
+		foobar := bytes.Equal([]byte{0x01, 0x0a, 0x06, 0x66, 0x6F, 0x6F, 0x02, 0x01, 0x0a, 0x06, 0x62, 0x61, 0x72, 0x04, 0x0}, buf.Bytes())
+		// {"bar": 2, "foo": 1}
+		barfoo := bytes.Equal([]byte{0x01, 0x0a, 0x06, 0x62, 0x61, 0x72, 0x04, 0x01, 0x0a, 0x06, 0x66, 0x6F, 0x6F, 0x02, 0x0}, buf.Bytes())
+		return (foobar || barfoo)
+	})
+}


### PR DESCRIPTION
This commit fixes the following error when encoding a map with more than `blocklength` keys.

```go
package main

import (
	"bytes"
	"encoding/json"
	"log"

	"github.com/hamba/avro"
)

var Schema = `{
		"type": "record",
		"name": "simple",
		"namespace": "org.hamba.avro",
		"fields" : [
			{
				"name": "properties",
				"type": {
					"type": "map",
					"values": "int"
				}
			}
		]
	}`

type SimpleRecord struct {
	Properties map[string]int `avro:"properties"`
}

func main() {
	avro.DefaultConfig = avro.Config{
		TagKey:               "avro",
		BlockLength:          1,
		UnionResolutionError: true,
	}.Freeze()

	schema, err := avro.Parse(Schema)
	if err != nil {
		log.Fatal(err)
	}

	data := []byte(`
	{
		"properties": {
			"1": 1,
			"2": 2
		}
	}
	`)

	in := SimpleRecord{}

	buffer := bytes.NewReader(data)
	decoder := json.NewDecoder(buffer)

	err = decoder.Decode(&in)
	if err != nil {
		log.Fatal(err)
	}

	_, err = avro.Marshal(schema, in)
	if err != nil {
		log.Fatal(err)
	}
}
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x119f7bf]

goroutine 1 [running]:
github.com/hamba/avro.(*mapEncoder).Encode.func1(0xc0000205c0, 0xc000117c26)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/codec_map.go:107 +0x6f
github.com/hamba/avro.(*Writer).WriteBlockCB(0xc0000205c0, 0xc000117cd0, 0x124b580)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/writer.go:183 +0xe9
github.com/hamba/avro.(*mapEncoder).Encode(0xc00000c980, 0xc000117e08, 0xc0000205c0)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/codec_map.go:103 +0xe3
github.com/hamba/avro.(*structFieldEncoder).Encode(0xc00000c9a0, 0xc000117e08, 0xc0000205c0)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/codec_record.go:187 +0x75
github.com/hamba/avro.(*structEncoder).Encode(0xc00005fc80, 0xc000117e08, 0xc0000205c0)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/codec_record.go:169 +0x5e
github.com/hamba/avro.(*onePtrEncoder).Encode(0xc000011620, 0xc00005fb90, 0xc0000205c0)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/codec.go:151 +0x4b
github.com/hamba/avro.(*Writer).WriteVal(0xc0000205c0, 0x124bd00, 0xc00007c280, 0x11d7ce0, 0xc00005fb90)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/codec.go:72 +0xd8
github.com/hamba/avro.(*frozenConfig).Marshal(0xc00005a190, 0x124bd00, 0xc00007c280, 0x11d7ce0, 0xc00005fb90, 0x124bd00, 0xc00007c280, 0x0, 0x0, 0xc000068f78)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/config.go:103 +0x70
github.com/hamba/avro.Marshal(...)
	/Users/h-izu/go/1.14.0/pkg/mod/github.com/hamba/avro@v1.1.2/encoder.go:38
main.main()
	/Users/h-izu/Documents/workspace/hambaavro/issue.go:61 +0x29f
```