### PR TITLE
ocf: add encoder Flush()

### DIFF
--- a/ocf/example_test.go
+++ b/ocf/example_test.go
@@ -72,7 +72,11 @@ func ExampleNewEncoder() {
 		log.Fatal(err)
 	}
 
-	if err := enc.Close(); err != nil {
+	if err := enc.Flush(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := f.Sync(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -259,8 +259,8 @@ func (e *Encoder) Encode(v interface{}) error {
 	return e.writer.Error
 }
 
-// Close closes the encoder, flushing the writer.
-func (e *Encoder) Close() error {
+// Flush flushes the underlying writer.
+func (e *Encoder) Flush() error {
 	if e.count == 0 {
 		return nil
 	}
@@ -270,6 +270,11 @@ func (e *Encoder) Close() error {
 	}
 
 	return e.writer.Error
+}
+
+// Close closes the encoder, flushing the writer.
+func (e *Encoder) Close() error {
+	return e.Flush()
 }
 
 func (e *Encoder) writerBlock() error {


### PR DESCRIPTION
It seems that encoder.Close() does not close anything, but it just flushes
the block, i added Flush() kept Close() but added a deprecation note.