### PR TITLE
ocf: add WithWriterConfig

### DIFF
--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -158,6 +158,7 @@ type encoderConfig struct {
 	BlockLength int
 	CodecName   CodecName
 	Metadata    map[string][]byte
+	API         avro.API
 }
 
 // EncoderFunc represents an configuration function for Encoder.
@@ -181,6 +182,13 @@ func WithCodec(codec CodecName) EncoderFunc {
 func WithMetadata(meta map[string][]byte) EncoderFunc {
 	return func(cfg *encoderConfig) {
 		cfg.Metadata = meta
+	}
+}
+
+// WithWriterConfig sets the config for the internal writer.
+func WithWriterConfig(api avro.API) EncoderFunc {
+	return func(cfg *encoderConfig) {
+		cfg.API = api
 	}
 }
 
@@ -208,12 +216,13 @@ func NewEncoder(s string, w io.Writer, opts ...EncoderFunc) (*Encoder, error) {
 		BlockLength: 100,
 		CodecName:   Null,
 		Metadata:    map[string][]byte{},
+		API:         avro.DefaultConfig,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
-	writer := avro.NewWriter(w, 512)
+	writer := avro.NewWriter(w, 512, avro.WithWriterConfig(cfg.API))
 
 	cfg.Metadata[schemaKey] = []byte(schema.String())
 	cfg.Metadata[codecKey] = []byte(cfg.CodecName)

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -243,7 +243,7 @@ func NewEncoder(s string, w io.Writer, opts ...EncoderFunc) (*Encoder, error) {
 	e := &Encoder{
 		writer:      writer,
 		buf:         buf,
-		encoder:     avro.NewEncoderForSchema(schema, buf),
+		encoder:     cfg.API.NewEncoder(schema, buf),
 		sync:        header.Sync,
 		codec:       codec,
 		blockLength: cfg.BlockLength,


### PR DESCRIPTION
Allows users to control the writer used by the encoder, my main use case is to set the `Config.BlockLength` for arrays and maps.

For some reason, bigquery's avro reader encounters an EOF error when an array of 101 is sent to it, it might be an internal bigquery problem as the official apache tools can read the file. Increasing the blocklength to 200 solves the issue.