### PR TITLE
ocf: fix header schema to avoid data race

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -8,7 +8,6 @@ import (
 	"hash"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"github.com/hamba/avro/pkg/crc64"
@@ -210,8 +209,8 @@ func (n name) FullName() string {
 }
 
 type fingerprinter struct {
-	fingerprint atomic.Value
-	cache       sync.Map
+	fingerprint atomic.Value   // [32]byte
+	cache       concurrent.Map // map[FingerprintType][]byte
 }
 
 // Fingerprint returns the SHA256 fingerprint of the schema.

--- a/schema.go
+++ b/schema.go
@@ -8,15 +8,14 @@ import (
 	"hash"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/hamba/avro/pkg/crc64"
 	"github.com/modern-go/concurrent"
 )
 
-var (
-	emptyFgpt   = [32]byte{}
-	nullDefault = struct{}{}
-)
+var nullDefault = struct{}{}
 
 // Type is a schema type.
 type Type string
@@ -211,28 +210,25 @@ func (n name) FullName() string {
 }
 
 type fingerprinter struct {
-	fingerprint [32]byte
-	cache       map[FingerprintType][]byte
+	fingerprint atomic.Value
+	cache       sync.Map
 }
 
 // Fingerprint returns the SHA256 fingerprint of the schema.
 func (f *fingerprinter) Fingerprint(stringer fmt.Stringer) [32]byte {
-	if f.fingerprint != emptyFgpt {
-		return f.fingerprint
+	if v := f.fingerprint.Load(); v != nil {
+		return v.([32]byte)
 	}
 
-	f.fingerprint = sha256.Sum256([]byte(stringer.String()))
-	return f.fingerprint
+	fingerprint := sha256.Sum256([]byte(stringer.String()))
+	f.fingerprint.Store(fingerprint)
+	return fingerprint
 }
 
 // FingerprintUsing returns the fingerprint of the schema using the given algorithm or an error.
 func (f *fingerprinter) FingerprintUsing(typ FingerprintType, stringer fmt.Stringer) ([]byte, error) {
-	if f.cache == nil {
-		f.cache = map[FingerprintType][]byte{}
-	}
-
-	if b, ok := f.cache[typ]; ok {
-		return b, nil
+	if v, ok := f.cache.Load(typ); ok {
+		return v.([]byte), nil
 	}
 
 	h, ok := fingerprinters[typ]
@@ -243,7 +239,7 @@ func (f *fingerprinter) FingerprintUsing(typ FingerprintType, stringer fmt.Strin
 	h.Reset()
 	_, _ = h.Write([]byte(stringer.String()))
 	fingerprint := h.Sum(make([]byte, 0, h.Size()))
-	f.cache[typ] = fingerprint
+	f.cache.Store(typ, fingerprint)
 	return fingerprint, nil
 }
 

--- a/schema_internal_test.go
+++ b/schema_internal_test.go
@@ -333,6 +333,8 @@ func TestSchema_FingerprintUsingCaches(t *testing.T) {
 
 	got, _ := schema.FingerprintUsing(CRC64Avro)
 
-	assert.Equal(t, want, schema.cache[CRC64Avro])
+	value, ok := schema.cache.Load(CRC64Avro)
+	assert.True(t, ok)
+	assert.Equal(t, want, value)
 	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
I use this excellent avro library because this is three times faster than linkedin/goavro in my work load.
I found that data-race occurred in multi thread program when I used this library.
That is because `ocf.go` shares `HeaderSchema` instance in `github.com/hamba/avro.(*fingerprinter).Fingerprint()` which is not thread safe.

At first, I attempted to fix `fingerprinter.Fingerprint()` to make it thread safe, but it ended up with less performance.
So, I fix `ocf.go` to avoid sharing a `HeaderSchema` instance.

I write a simple data-race example.
https://github.com/getumen/avro-datarace-example/blob/main/main.go
```
[yoshihiro@MBP] ( ﾟ∀ﾟ)・∵. ~/github/avro-datarace-example % go run -race ./main.go                                                                                                                                                                        (git)-[main]
==================
WARNING: DATA RACE
Read at 0x00c0000dc2d0 by goroutine 10:
  github.com/hamba/avro.(*fingerprinter).Fingerprint()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/schema.go:221 +0x16c
  github.com/hamba/avro.(*RecordSchema).Fingerprint()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/schema.go:407 +0x5c
  github.com/hamba/avro.(*Reader).ReadVal()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/codec.go:42 +0xc3
  github.com/hamba/avro/ocf.NewDecoder()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/ocf/ocf.go:63 +0x129
  main.main.func1()
      /Users/yoshihiro/github/avro-datarace-example/main.go:31 +0xdc

Previous write at 0x00c0000dc2d0 by goroutine 8:
  github.com/hamba/avro.(*fingerprinter).Fingerprint()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/schema.go:224 +0xf4
  github.com/hamba/avro.(*RecordSchema).Fingerprint()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/schema.go:407 +0x5c
  github.com/hamba/avro.(*Reader).ReadVal()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/codec.go:42 +0xc3
  github.com/hamba/avro/ocf.NewDecoder()
      /Users/yoshihiro/go/1.15.3/pkg/mod/github.com/hamba/avro@v1.5.1/ocf/ocf.go:63 +0x129
  main.main.func1()
      /Users/yoshihiro/github/avro-datarace-example/main.go:31 +0xdc

Goroutine 10 (running) created at:
  main.main()
      /Users/yoshihiro/github/avro-datarace-example/main.go:27 +0x126

Goroutine 8 (running) created at:
  main.main()
      /Users/yoshihiro/github/avro-datarace-example/main.go:27 +0x126
==================
```