### PR TITLE
fix: map union ptr type encoding

### DIFF
--- a/codec_union.go
+++ b/codec_union.go
@@ -140,7 +140,12 @@ func (e *mapUnionEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 
 	elemType := reflect2.TypeOf(val)
 	elemPtr := reflect2.PtrOf(val)
-	encoderOfType(e.cfg, schema, elemType).Encode(elemPtr, w)
+
+	encoder := encoderOfType(e.cfg, schema, elemType)
+	if elemType.LikePtr() {
+		encoder = &onePtrEncoder{encoder}
+	}
+	encoder.Encode(elemPtr, w)
 }
 
 func decoderOfPtrUnion(cfg *frozenConfig, schema Schema, typ reflect2.Type) ValDecoder {

--- a/encoder_union_test.go
+++ b/encoder_union_test.go
@@ -22,6 +22,27 @@ func TestEncoder_UnionMap(t *testing.T) {
 	assert.Equal(t, []byte{0x02, 0x06, 0x66, 0x6F, 0x6F}, buf.Bytes())
 }
 
+func TestEncoder_UnionMapRecord(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["null", {
+	"type": "record",
+	"name": "test",
+	"fields" : [
+		{"name": "a", "type": ["string", "null"], "default": "test"},
+	    {"name": "b", "type": "string"}
+	]
+}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	assert.NoError(t, err)
+
+	err = enc.Encode(map[string]interface{}{"test": map[string]interface{}{"b": "foo"}})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00, 0x08, 0x74, 0x65, 0x73, 0x74, 0x06, 0x66, 0x6F, 0x6F}, buf.Bytes())
+}
+
 func TestEncoder_UnionMapNamed(t *testing.T) {
 	defer ConfigTeardown()
 


### PR DESCRIPTION
When doing a map union encode, object that are like pointer need their encoders wrapped.

Fixes #82