### PR TITLE
fix: deref the reference schema

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1048,6 +1048,10 @@ func isValidDefault(schema Schema, def interface{}) (interface{}, bool) {
 }
 
 func schemaTypeName(schema Schema) string {
+	if schema.Type() == Ref {
+		schema = schema.(*RefSchema).Schema()
+	}
+
 	if n, ok := schema.(NamedSchema); ok {
 		return n.FullName()
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -662,6 +662,12 @@ func TestUnionSchema(t *testing.T) {
 			wantErr:         false,
 		},
 		{
+			name:    "Dereferences Ref Schemas",
+			schema:  `[{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}, {"type":"enum", "name":"test1", "namespace": "org.hamba.avro", "symbols":["TEST"]}, {"type":"record", "name":"test2", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": ["null","org.hamba.avro.test","org.hamba.avro.test1"]}]}]`,
+			wantFingerprint: [32]byte{0xc1, 0x42, 0x87, 0xde, 0x24, 0x3d, 0xee, 0x1d, 0xa5, 0x47, 0xa0, 0x13, 0x9e, 0xb, 0xe0, 0x6, 0xfd, 0xa, 0x76, 0xd9, 0xe8, 0x92, 0x9a, 0xd3, 0x46, 0xf, 0xbd, 0x86, 0x21, 0x72, 0x81, 0x1b},
+			wantErr: false,
+		},
+		{
 			name:    "No Nested Union Type",
 			schema:  `["null", ["string"]]`,
 			wantErr: true,


### PR DESCRIPTION
When getting the schema type name for a union, a reference schema must be dereferenced before finding the name.

Fixes #107 