### PR TITLE
avro: rework schema parsing

### DIFF
--- a/codec_record.go
+++ b/codec_record.go
@@ -60,6 +60,14 @@ func decoderOfStruct(cfg *frozenConfig, schema Schema, typ reflect2.Type) ValDec
 	fields := make([]*structFieldDecoder, 0, len(rec.Fields()))
 	for _, field := range rec.Fields() {
 		sf := structDesc.Fields.Get(field.Name())
+		if sf == nil {
+			for _, alias := range field.Aliases() {
+				sf = structDesc.Fields.Get(alias)
+				if sf != nil {
+					break
+				}
+			}
+		}
 
 		// Skip field if it doesnt exist
 		if sf == nil {

--- a/decoder_record_test.go
+++ b/decoder_record_test.go
@@ -74,6 +74,28 @@ func TestDecoder_RecordStructPtrNil(t *testing.T) {
 	assert.Equal(t, &TestRecord{A: 27, B: "foo"}, got)
 }
 
+func TestDecoder_RecordStructWithFieldAlias(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x36, 0x06, 0x66, 0x6f, 0x6f}
+	schema := `{
+	"type": "record",
+	"name": "test",
+	"fields" : [
+		{"name": "c", "aliases": ["a"], "type": "long"},
+	    {"name": "b", "type": "string"}
+	]
+}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	assert.NoError(t, err)
+
+	var got TestRecord
+	err = dec.Decode(&got)
+
+	assert.NoError(t, err)
+	assert.Equal(t, TestRecord{A: 27, B: "foo"}, got)
+}
+
 func TestDecoder_RecordPartialStruct(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.11
 require (
 	github.com/golang/snappy v0.0.4
 	github.com/json-iterator/go v1.1.12
+	github.com/mitchellh/mapstructure v1.4.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
+github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/protocol.go
+++ b/protocol.go
@@ -52,7 +52,12 @@ type Protocol struct {
 }
 
 // NewProtocol creates a protocol instance.
-func NewProtocol(name, namepsace string, types []NamedSchema, messages map[string]*Message, opts ...ProtocolOption) (*Protocol, error) {
+func NewProtocol(
+	name, namepsace string,
+	types []NamedSchema,
+	messages map[string]*Message,
+	opts ...ProtocolOption,
+) (*Protocol, error) {
 	var cfg protocolConfig
 	for _, opt := range opts {
 		opt(&cfg)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hamba/avro"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMustParseProtocol(t *testing.T) {
@@ -26,7 +27,7 @@ func TestNewProtocol_ValidatesName(t *testing.T) {
 }
 
 func TestNewMessage(t *testing.T) {
-	field, _ := avro.NewField("test", avro.NewPrimitiveSchema(avro.String, nil), nil)
+	field, _ := avro.NewField("test", avro.NewPrimitiveSchema(avro.String, nil))
 	fields := []*avro.Field{field}
 	req, _ := avro.NewRecordSchema("test", "", fields)
 	resp := avro.NewPrimitiveSchema(avro.String, nil)
@@ -45,110 +46,106 @@ func TestParseProtocol(t *testing.T) {
 	tests := []struct {
 		name    string
 		schema  string
-		wantErr bool
+		wantErr assert.ErrorAssertionFunc
 	}{
 		{
 			name:    "Valid",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "doc": "docs"}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Invalid Json",
 			schema:  `{`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Invalid Name First Char",
 			schema:  `{"protocol":"0test", "namespace": "org.hamba.avro"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Invalid Name Other Char",
 			schema:  `{"protocol":"test+", "namespace": "org.hamba.avro"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Empty Name",
 			schema:  `{"protocol":"", "namespace": "org.hamba.avro"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "No Name",
 			schema:  `{"namespace": "org.hamba.avro"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Invalid Namespace",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro+"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Empty Namespace",
 			schema:  `{"protocol":"test", "namespace": ""}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Invalid Type Schema",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "types":["test"]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Type Not Named Schema",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "types":["string"]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Not Object",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":["test"]}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Request Invalid Request Json",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": "test"}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Request Invalid Field",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": [{"name": "foobar"}]}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Response Invalid Schema",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": [{"name": "foobar", "type": "string"}], "response": "test"}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Errors Invalid Schema",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": [{"name": "foobar", "type": "string"}], "errors": ["test"]}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Errors Record Not Error Schema",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": [{"name": "foobar", "type": "string"}], "errors": [{"type":"record", "name":"test", "fields":[{"name": "field", "type": "int"}]}]}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message Errors Duplicate Schema",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": [{"name": "foobar", "type": "string"}], "errors": ["string"]}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Message One Way Invalid",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro", "messages":{"test":{"request": [{"name": "foobar", "type": "string"}], "errors": ["int"], "one-way": true}}}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := avro.ParseProtocol(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, err := avro.ParseProtocol(test.schema)
 
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
+			test.wantErr(t, err)
 		})
 	}
 }
@@ -158,11 +155,24 @@ func TestParseProtocol_DeterminesOneWayMessage(t *testing.T) {
 
 	proto, err := avro.ParseProtocol(schema)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	msg := proto.Message("test")
-	assert.NotNil(t, msg)
+	require.NotNil(t, msg)
 	assert.True(t, msg.OneWay())
+}
+
+func TestParseProtocol_Docs(t *testing.T) {
+	schema := `{"protocol":"test", "doc": "foo", "messages":{"test":{"request": [{"name": "foobar", "type": "string"}], "doc": "bar"}}}`
+
+	proto, err := avro.ParseProtocol(schema)
+	require.NoError(t, err)
+
+	assert.Equal(t, "foo", proto.Doc())
+
+	msg := proto.Message("test")
+	require.NotNil(t, msg)
+	assert.Equal(t, "bar", msg.Doc())
 }
 
 func TestParseProtocolFile(t *testing.T) {
@@ -170,7 +180,7 @@ func TestParseProtocolFile(t *testing.T) {
 
 	want := `{"protocol":"Echo","namespace":"org.hamba.avro","types":[{"name":"org.hamba.avro.Ping","type":"record","fields":[{"name":"timestamp","type":"long"},{"name":"text","type":"string"}]},{"name":"org.hamba.avro.Pong","type":"record","fields":[{"name":"timestamp","type":"long"},{"name":"ping","type":"org.hamba.avro.Ping"}]},{"name":"org.hamba.avro.PongError","type":"error","fields":[{"name":"timestamp","type":"long"},{"name":"reason","type":"string"}]}],"messages":{"ping":{"request":[{"name":"ping","type":"org.hamba.avro.Ping"}],"response":"org.hamba.avro.Pong","errors":["org.hamba.avro.PongError"]}}}`
 	wantMD5 := "5bc594ae86fc8c209f553ce3bc4291a5"
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, want, protocol.String())
 	assert.Equal(t, wantMD5, protocol.Hash())
 }

--- a/schema.go
+++ b/schema.go
@@ -17,6 +17,14 @@ import (
 
 var nullDefault = struct{}{}
 
+var (
+	schemaReserved = []string{
+		"doc", "fields", "items", "name", "namespace", "size", "symbols",
+		"values", "type", "aliases", "logicalType", "precision", "scale",
+	}
+	fieldReserved = []string{"default", "doc", "name", "order", "type", "aliases"}
+)
+
 // Type is a schema type.
 type Type string
 
@@ -130,11 +138,6 @@ type LogicalSchema interface {
 
 // PropertySchema represents a schema with properties.
 type PropertySchema interface {
-	// AddProp adds a property to the schema.
-	//
-	// AddProp will not overwrite existing properties.
-	AddProp(name string, value interface{})
-
 	// Prop gets a property from the schema.
 	Prop(string) interface{}
 }
@@ -161,32 +164,56 @@ type LogicalTypeSchema interface {
 }
 
 type name struct {
-	name  string
-	space string
-	full  string
+	name      string
+	namespace string
+	full      string
+	aliases   []string
 }
 
-func newName(n, s string) (name, error) {
+func newName(n, ns string, aliases []string) (name, error) {
 	if idx := strings.LastIndexByte(n, '.'); idx > -1 {
-		s = n[:idx]
+		ns = n[:idx]
 		n = n[idx+1:]
 	}
 
 	full := n
-	if s != "" {
-		full = s + "." + n
+	if ns != "" {
+		full = ns + "." + n
 	}
 
 	for _, part := range strings.Split(full, ".") {
 		if err := validateName(part); err != nil {
-			return name{}, err
+			return name{}, fmt.Errorf("avro: invalid name part %q in name %q: %w", full, part, err)
 		}
 	}
 
+	a := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		if strings.Index(alias, ".") == -1 {
+			if err := validateName(alias); err != nil {
+				return name{}, fmt.Errorf("avro: invalid name %q: %w", alias, err)
+			}
+			if ns == "" {
+				a = append(a, alias)
+				continue
+			}
+			a = append(a, ns+"."+alias)
+			continue
+		}
+
+		for _, part := range strings.Split(alias, ".") {
+			if err := validateName(part); err != nil {
+				return name{}, fmt.Errorf("avro: invalid name part %q in name %q: %w", full, part, err)
+			}
+		}
+		a = append(a, alias)
+	}
+
 	return name{
-		name:  n,
-		space: s,
-		full:  full,
+		name:      n,
+		namespace: ns,
+		full:      full,
+		aliases:   a,
 	}, nil
 }
 
@@ -197,12 +224,17 @@ func (n name) Name() string {
 
 // Namespace returns the namespace of a schema.
 func (n name) Namespace() string {
-	return n.space
+	return n.namespace
 }
 
-// FullName returns the full qualified name of a schema.
+// FullName returns the fully qualified name of a schema.
 func (n name) FullName() string {
 	return n.full
+}
+
+// Aliases returns the fully qualified aliases of a schema.
+func (n name) Aliases() []string {
+	return n.aliases
 }
 
 type fingerprinter struct {
@@ -240,41 +272,82 @@ func (f *fingerprinter) FingerprintUsing(typ FingerprintType, stringer fmt.Strin
 }
 
 type properties struct {
-	reserved []string
-	props    map[string]interface{}
+	props map[string]interface{}
 }
 
-// AddProp adds a property to the schema.
-//
-// AddProp will not overwrite existing properties.
-func (p *properties) AddProp(name string, value interface{}) {
-	// Create the props is needed.
-	if p.props == nil {
-		p.props = map[string]interface{}{}
+func newProperties(props map[string]interface{}, res []string) properties {
+	p := properties{props: map[string]interface{}{}}
+	for k, v := range props {
+		if isReserved(res, k) {
+			continue
+		}
+		p.props[k] = v
 	}
+	return p
+}
 
-	// Dont allow reserved properties
-	for _, res := range p.reserved {
-		if name == res {
-			return
+func isReserved(res []string, k string) bool {
+	for _, r := range res {
+		if k == r {
+			return true
 		}
 	}
-
-	// Dont overwrite a property
-	if _, ok := p.props[name]; ok {
-		return
-	}
-
-	p.props[name] = value
+	return false
 }
 
 // Prop gets a property from the schema.
-func (p *properties) Prop(name string) interface{} {
+func (p properties) Prop(name string) interface{} {
 	if p.props == nil {
 		return nil
 	}
 
 	return p.props[name]
+}
+
+type schemaConfig struct {
+	aliases []string
+	doc     string
+	def     interface{}
+	order   string
+	props   map[string]interface{}
+}
+
+// SchemaOption is a function that sets a schema option.
+type SchemaOption func(*schemaConfig)
+
+// WithAliases sets the aliases on a schema.
+func WithAliases(aliases []string) SchemaOption {
+	return func(opts *schemaConfig) {
+		opts.aliases = aliases
+	}
+}
+
+// WithDoc sets the doc on a schema.
+func WithDoc(doc string) SchemaOption {
+	return func(opts *schemaConfig) {
+		opts.doc = doc
+	}
+}
+
+// WithDefault sets the default on a schema.
+func WithDefault(def interface{}) SchemaOption {
+	return func(opts *schemaConfig) {
+		opts.def = def
+	}
+}
+
+// WithOrder sets the order on a schema.
+func WithOrder(order string) SchemaOption {
+	return func(opts *schemaConfig) {
+		opts.order = order
+	}
+}
+
+// WithProps sets the properties on a schema.
+func WithProps(props map[string]interface{}) SchemaOption {
+	return func(opts *schemaConfig) {
+		opts.props = props
+	}
 }
 
 // PrimitiveSchema is an Avro primitive type schema.
@@ -335,35 +408,40 @@ type RecordSchema struct {
 
 	isError bool
 	fields  []*Field
+
+	doc string
 }
 
 // NewRecordSchema creates a new record schema instance.
-func NewRecordSchema(name, space string, fields []*Field) (*RecordSchema, error) {
-	n, err := newName(name, space)
+func NewRecordSchema(name, namespace string, fields []*Field, opts ...SchemaOption) (*RecordSchema, error) {
+	var cfg schemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	n, err := newName(name, namespace, cfg.aliases)
 	if err != nil {
 		return nil, err
 	}
 
 	return &RecordSchema{
 		name:       n,
-		properties: properties{reserved: schemaReserved},
+		properties: newProperties(cfg.props, schemaReserved),
 		fields:     fields,
+		doc:        cfg.doc,
 	}, nil
 }
 
 // NewErrorRecordSchema creates a new error record schema instance.
-func NewErrorRecordSchema(name, space string, fields []*Field) (*RecordSchema, error) {
-	n, err := newName(name, space)
+func NewErrorRecordSchema(name, namespace string, fields []*Field, opts ...SchemaOption) (*RecordSchema, error) {
+	rec, err := NewRecordSchema(name, namespace, fields, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	return &RecordSchema{
-		name:       n,
-		properties: properties{reserved: schemaReserved},
-		isError:    true,
-		fields:     fields,
-	}, nil
+	rec.isError = true
+
+	return rec, nil
 }
 
 // Type returns the type of the schema.
@@ -379,6 +457,11 @@ func (s *RecordSchema) IsError() bool {
 // Fields returns the fields of a record.
 func (s *RecordSchema) Fields() []*Field {
 	return s.fields
+}
+
+// Doc returns the record doc.
+func (s *RecordSchema) Doc() string {
+	return s.doc
 }
 
 // String returns the canonical form of the schema.
@@ -407,13 +490,17 @@ func (s *RecordSchema) MarshalJSON() ([]byte, error) {
 	}
 
 	ss := struct {
-		Name   string   `json:"name"`
-		Type   string   `json:"type"`
-		Fields []*Field `json:"fields"`
+		Name    string   `json:"name"`
+		Aliases []string `json:"aliases,omitempty"`
+		Doc     string   `json:"doc,omitempty"`
+		Type    string   `json:"type"`
+		Fields  []*Field `json:"fields"`
 	}{
-		Name:   s.FullName(),
-		Type:   typ,
-		Fields: s.fields,
+		Name:    s.full,
+		Aliases: s.aliases,
+		Doc:     s.doc,
+		Type:    typ,
+		Fields:  s.fields,
 	}
 
 	return jsoniter.Marshal(ss)
@@ -433,10 +520,13 @@ func (s *RecordSchema) FingerprintUsing(typ FingerprintType) ([]byte, error) {
 type Field struct {
 	properties
 
-	name   string
-	typ    Schema
-	hasDef bool
-	def    interface{}
+	name    string
+	aliases []string
+	doc     string
+	typ     Schema
+	hasDef  bool
+	def     interface{}
+	order   string
 }
 
 type noDef struct{}
@@ -445,19 +535,40 @@ type noDef struct{}
 var NoDefault = noDef{}
 
 // NewField creates a new field instance.
-func NewField(name string, typ Schema, def interface{}) (*Field, error) {
+func NewField(name string, typ Schema, opts ...SchemaOption) (*Field, error) {
+	var cfg schemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	if err := validateName(name); err != nil {
 		return nil, err
 	}
-
-	f := &Field{
-		properties: properties{reserved: fieldReserved},
-		name:       name,
-		typ:        typ,
+	for _, a := range cfg.aliases {
+		if err := validateName(a); err != nil {
+			return nil, err
+		}
 	}
 
-	if def != NoDefault {
-		def, err := validateDefault(name, typ, def)
+	switch cfg.order {
+	case "":
+		cfg.order = "ascending"
+	case "ascending", "descending", "ignore":
+	default:
+		return nil, fmt.Errorf("avro: field %q order %q is invalid", name, cfg.order)
+	}
+
+	f := &Field{
+		properties: newProperties(cfg.props, fieldReserved),
+		name:       name,
+		aliases:    cfg.aliases,
+		doc:        cfg.doc,
+		typ:        typ,
+		order:      cfg.order,
+	}
+
+	if cfg.def != NoDefault {
+		def, err := validateDefault(name, typ, cfg.def)
 		if err != nil {
 			return nil, err
 		}
@@ -473,9 +584,19 @@ func (f *Field) Name() string {
 	return f.name
 }
 
+// Aliases return the field aliases.
+func (f *Field) Aliases() []string {
+	return f.aliases
+}
+
 // Type returns the schema of a field.
 func (f *Field) Type() Schema {
 	return f.typ
+}
+
+// Doc returns the field doc.
+func (f *Field) Doc() string {
+	return f.doc
 }
 
 // HasDefault determines if the field has a default value.
@@ -494,6 +615,11 @@ func (f *Field) Default() interface{} {
 	return f.def
 }
 
+// Order returns the field order.
+func (f *Field) Order() string {
+	return f.order
+}
+
 // String returns the canonical form of a field.
 func (f *Field) String() string {
 	return `{"name":"` + f.name + `","type":` + f.typ.String() + `}`
@@ -503,14 +629,22 @@ func (f *Field) String() string {
 func (f *Field) MarshalJSON() ([]byte, error) {
 	s := struct {
 		Name    string      `json:"name"`
+		Aliases []string    `json:"aliases,omitempty"`
+		Doc     string      `json:"doc,omitempty"`
 		Type    Schema      `json:"type"`
 		Default interface{} `json:"default,omitempty"`
+		Order   string      `json:"order,omitempty"`
 	}{
-		Name: f.name,
-		Type: f.typ,
+		Name:    f.name,
+		Aliases: f.aliases,
+		Doc:     f.doc,
+		Type:    f.typ,
 	}
 	if f.hasDef {
 		s.Default = f.def
+	}
+	if f.order != "ascending" {
+		s.Order = f.order
 	}
 	return jsoniter.Marshal(s)
 }
@@ -523,11 +657,18 @@ type EnumSchema struct {
 
 	symbols []string
 	def     string
+
+	doc string
 }
 
 // NewEnumSchema creates a new enum schema instance.
-func NewEnumSchema(name, namespace string, symbols []string) (*EnumSchema, error) {
-	n, err := newName(name, namespace)
+func NewEnumSchema(name, namespace string, symbols []string, opts ...SchemaOption) (*EnumSchema, error) {
+	var cfg schemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	n, err := newName(name, namespace, cfg.aliases)
 	if err != nil {
 		return nil, err
 	}
@@ -535,17 +676,36 @@ func NewEnumSchema(name, namespace string, symbols []string) (*EnumSchema, error
 	if len(symbols) == 0 {
 		return nil, errors.New("avro: enum must have a non-empty array of symbols")
 	}
-	for _, symbol := range symbols {
-		if err = validateName(symbol); err != nil {
-			return nil, fmt.Errorf("avro: invalid symnol %s", symbol)
+	for _, sym := range symbols {
+		if err = validateName(sym); err != nil {
+			return nil, fmt.Errorf("avro: invalid symnol %q", sym)
 		}
+	}
+
+	var def string
+	if d, ok := cfg.def.(string); ok && d != "" {
+		if !hasSymbol(symbols, d) {
+			return nil, fmt.Errorf("avro: symbol default %q must be a symbol", d)
+		}
+		def = d
 	}
 
 	return &EnumSchema{
 		name:       n,
-		properties: properties{reserved: schemaReserved},
+		properties: newProperties(cfg.props, schemaReserved),
 		symbols:    symbols,
+		def:        def,
+		doc:        cfg.doc,
 	}, nil
+}
+
+func hasSymbol(symbols []string, sym string) bool {
+	for _, s := range symbols {
+		if s == sym {
+			return true
+		}
+	}
+	return false
 }
 
 // Type returns the type of the schema.
@@ -553,9 +713,19 @@ func (s *EnumSchema) Type() Type {
 	return Enum
 }
 
+// Doc returns the schema doc.
+func (s *EnumSchema) Doc() string {
+	return s.doc
+}
+
 // Symbols returns the symbols of an enum.
 func (s *EnumSchema) Symbols() []string {
 	return s.symbols
+}
+
+// Default returns the default of an enum or an empty string.
+func (s *EnumSchema) Default() string {
+	return s.def
 }
 
 // String returns the canonical form of the schema.
@@ -575,11 +745,15 @@ func (s *EnumSchema) String() string {
 func (s *EnumSchema) MarshalJSON() ([]byte, error) {
 	ss := struct {
 		Name    string   `json:"name"`
+		Aliases []string `json:"aliases,omitempty"`
+		Doc     string   `json:"doc,omitempty"`
 		Type    string   `json:"type"`
 		Symbols []string `json:"symbols"`
 		Default string   `json:"default,omitempty"`
 	}{
-		Name:    s.FullName(),
+		Name:    s.full,
+		Aliases: s.aliases,
+		Doc:     s.doc,
 		Type:    "enum",
 		Symbols: s.symbols,
 		Default: s.def,
@@ -606,9 +780,14 @@ type ArraySchema struct {
 }
 
 // NewArraySchema creates an array schema instance.
-func NewArraySchema(items Schema) *ArraySchema {
+func NewArraySchema(items Schema, opts ...SchemaOption) *ArraySchema {
+	var cfg schemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	return &ArraySchema{
-		properties: properties{reserved: schemaReserved},
+		properties: newProperties(cfg.props, schemaReserved),
 		items:      items,
 	}
 }
@@ -659,9 +838,14 @@ type MapSchema struct {
 }
 
 // NewMapSchema creates a map schema instance.
-func NewMapSchema(values Schema) *MapSchema {
+func NewMapSchema(values Schema, opts ...SchemaOption) *MapSchema {
+	var cfg schemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	return &MapSchema{
-		properties: properties{reserved: schemaReserved},
+		properties: newProperties(cfg.props, schemaReserved),
 		values:     values,
 	}
 }
@@ -727,7 +911,7 @@ func NewUnionSchema(types []Schema) (*UnionSchema, error) {
 	}
 
 	return &UnionSchema{
-		types: Schemas(types),
+		types: types,
 	}, nil
 }
 
@@ -802,15 +986,20 @@ type FixedSchema struct {
 }
 
 // NewFixedSchema creates a new fixed schema instance.
-func NewFixedSchema(name, namespace string, size int, logical LogicalSchema) (*FixedSchema, error) {
-	n, err := newName(name, namespace)
+func NewFixedSchema(name, namespace string, size int, logical LogicalSchema, opts ...SchemaOption) (*FixedSchema, error) {
+	var cfg schemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	n, err := newName(name, namespace, cfg.aliases)
 	if err != nil {
 		return nil, err
 	}
 
 	return &FixedSchema{
 		name:       n,
-		properties: properties{reserved: schemaReserved},
+		properties: newProperties(cfg.props, schemaReserved),
 		size:       size,
 		logical:    logical,
 	}, nil
@@ -845,7 +1034,28 @@ func (s *FixedSchema) String() string {
 
 // MarshalJSON marshals the schema to json.
 func (s *FixedSchema) MarshalJSON() ([]byte, error) {
-	return []byte(s.String()), nil
+	ss := struct {
+		Name    string   `json:"name"`
+		Aliases []string `json:"aliases,omitempty"`
+		Type    string   `json:"type"`
+		Size    int      `json:"size"`
+	}{
+		Name:    s.full,
+		Aliases: s.aliases,
+		Type:    "fixed",
+		Size:    s.size,
+	}
+	json, err := jsoniter.MarshalToString(ss)
+	if err != nil {
+		return nil, err
+	}
+
+	var logical string
+	if s.logical != nil {
+		logical = "," + s.logical.String()
+	}
+
+	return []byte(json[:len(json)-1]+logical+"}"), nil
 }
 
 // Fingerprint returns the SHA256 fingerprint of the schema.
@@ -1001,15 +1211,15 @@ func invalidNameOtherChar(r rune) bool {
 }
 
 func validateName(name string) error {
-	if len(name) == 0 {
-		return errors.New("avro: name must be a non-empty")
+	if name == "" {
+		return errors.New("name must be a non-empty")
 	}
 
 	if strings.IndexFunc(name[:1], invalidNameFirstChar) > -1 {
-		return fmt.Errorf("avro: invalid name %s", name)
+		return fmt.Errorf("invalid name %s", name)
 	}
 	if strings.IndexFunc(name[1:], invalidNameOtherChar) > -1 {
-		return fmt.Errorf("avro: invalid name %s", name)
+		return fmt.Errorf("invalid name %s", name)
 	}
 
 	return nil

--- a/schema_compatibility_test.go
+++ b/schema_compatibility_test.go
@@ -18,234 +18,230 @@ func TestSchemaCompatibility_Compatible(t *testing.T) {
 		name    string
 		reader  string
 		writer  string
-		wantErr bool
+		wantErr assert.ErrorAssertionFunc
 	}{
 		{
 			name:    "Primitive Matching",
 			reader:  `"int"`,
 			writer:  `"int"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Int Promote Long",
 			reader:  `"long"`,
 			writer:  `"int"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Int Promote Float",
 			reader:  `"float"`,
 			writer:  `"int"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Int Promote Double",
 			reader:  `"double"`,
 			writer:  `"int"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Long Promote Float",
 			reader:  `"float"`,
 			writer:  `"long"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Long Promote Double",
 			reader:  `"double"`,
 			writer:  `"long"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Float Promote Double",
 			reader:  `"double"`,
 			writer:  `"float"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "String Promote Bytes",
 			reader:  `"bytes"`,
 			writer:  `"string"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Bytes Promote String",
 			reader:  `"string"`,
 			writer:  `"bytes"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Match",
 			reader:  `["int", "long", "string"]`,
 			writer:  `["string", "int", "long"]`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Reader Missing Schema",
 			reader:  `["int", "string"]`,
 			writer:  `["string", "int", "long"]`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Union Writer Missing Schema",
 			reader:  `["int", "long", "string"]`,
 			writer:  `["string", "int"]`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Writer Not Union",
 			reader:  `["int", "long", "string"]`,
 			writer:  `"int"`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Writer Not Union With Error",
 			reader:  `["string"]`,
 			writer:  `"int"`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Union Reader Not Union",
 			reader:  `"int"`,
 			writer:  `["int"]`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Reader Not Union With Error",
 			reader:  `"int"`,
 			writer:  `["string", "int", "long"]`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Array Match",
 			reader:  `{"type":"array", "items": "int"}`,
 			writer:  `{"type":"array", "items": "int"}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Array Items Mismatch",
 			reader:  `{"type":"array", "items": "int"}`,
 			writer:  `{"type":"array", "items": "string"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Map Match",
 			reader:  `{"type":"map", "values": "int"}`,
 			writer:  `{"type":"map", "values": "int"}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Map Items Mismatch",
 			reader:  `{"type":"map", "values": "int"}`,
 			writer:  `{"type":"map", "values": "string"}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Fixed Match",
 			reader:  `{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}`,
 			writer:  `{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Fixed Name Mismatch",
 			reader:  `{"type":"fixed", "name":"test1", "namespace": "org.hamba.avro", "size": 12}`,
 			writer:  `{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Fixed Size Mismatch",
 			reader:  `{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 13}`,
 			writer:  `{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Enum Match",
 			reader:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1", "TEST2"]}`,
 			writer:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1", "TEST2"]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Enum Name Mismatch",
 			reader:  `{"type":"enum", "name":"test1", "namespace": "org.hamba.avro", "symbols":["TEST1", "TEST2"]}`,
 			writer:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1", "TEST2"]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Enum Reader Missing Symbol",
 			reader:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1"]}`,
 			writer:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1", "TEST2"]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Enum Writer Missing Symbol",
 			reader:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1", "TEST2"]}`,
 			writer:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST1"]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Record Match",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int"}, {"name": "b", "type": "string"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "b", "type": "string"}, {"name": "a", "type": "int"}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Record Name Mismatch",
 			reader:  `{"type":"record", "name":"test1", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int", "default": 1}, {"name": "b", "type": "string"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "b", "type": "string", "default": "b"}, {"name": "a", "type": "int"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Record Schema Mismatch",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "string"}, {"name": "b", "type": "string"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "b", "type": "string"}, {"name": "a", "type": "int"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Record Reader Field Missing",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "b", "type": "string"}, {"name": "a", "type": "int"}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Record Writer Field Missing With Default",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int"}, {"name": "b", "type": "string", "default": "test"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int"}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Record Writer Field Missing Without Default",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int"}, {"name": "b", "type": "string"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Ref Dereference",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"record", "name":"test1", "namespace": "org.hamba.avro", "fields":[{"name": "b", "type": "int"}]}}, {"name": "b", "type": "test1"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"record", "name":"test1", "namespace": "org.hamba.avro", "fields":[{"name": "b", "type": "int"}]}}, {"name": "b", "type": "test"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Breaks Recursion",
 			reader:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "test"}]}`,
 			writer:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "test"}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := avro.MustParse(tt.reader)
-			w := avro.MustParse(tt.writer)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			r := avro.MustParse(test.reader)
+			w := avro.MustParse(test.writer)
 			sc := avro.NewSchemaCompatibility()
 
 			err := sc.Compatible(r, w)
 
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
+			test.wantErr(t, err)
 		})
 	}
 }

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -145,15 +145,15 @@ func TestSchema_JSON(t *testing.T) {
 		},
 		{
 			input: `{"fields":[], "type":"record", "name":"foo", "doc":"Useful info"}`,
-			json:  `{"name":"foo","type":"record","fields":[]}`,
+			json:  `{"name":"foo","doc":"Useful info","type":"record","fields":[]}`,
 		},
 		{
 			input: `{"fields":[], "type":"record", "name":"foo", "aliases":["foo","bar"]}`,
-			json:  `{"name":"foo","type":"record","fields":[]}`,
+			json:  `{"name":"foo","aliases":["foo","bar"],"type":"record","fields":[]}`,
 		},
 		{
 			input: `{"fields":[], "type":"record", "name":"foo", "doc":"foo", "aliases":["foo","bar"]}`,
-			json:  `{"name":"foo","type":"record","fields":[]}`,
+			json:  `{"name":"foo","aliases":["foo","bar"],"doc":"foo","type":"record","fields":[]}`,
 		},
 		{
 			input: `{"fields":[{"type":{"type":"boolean"}, "name":"f1"}], "type":"record", "name":"foo"}`,
@@ -161,11 +161,11 @@ func TestSchema_JSON(t *testing.T) {
 		},
 		{
 			input: `
-{ "fields":[{"type":"boolean", "aliases":[], "name":"f1", "default":true},
+{ "fields":[{"type":"boolean", "aliases":["foo"], "name":"f1", "default":true},
            {"order":"descending","name":"f2","doc":"Hello","type":"int"}],
  "type":"record", "name":"foo"
 }`,
-			json: `{"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean","default":true},{"name":"f2","type":"int"}]}`,
+			json: `{"name":"foo","type":"record","fields":[{"name":"f1","aliases":["foo"],"type":"boolean","default":true},{"name":"f2","doc":"Hello","type":"int","order":"descending"}]}`,
 		},
 		{
 			input: `{"type":"enum", "name":"foo", "symbols":["A1"]}`,
@@ -173,7 +173,7 @@ func TestSchema_JSON(t *testing.T) {
 		},
 		{
 			input: `{"namespace":"x.y.z", "type":"enum", "name":"foo", "doc":"foo bar", "symbols":["A1", "A2"]}`,
-			json:  `{"name":"x.y.z.foo","type":"enum","symbols":["A1","A2"]}`,
+			json:  `{"name":"x.y.z.foo","doc":"foo bar","type":"enum","symbols":["A1","A2"]}`,
 		},
 		{
 			input: `{"name":"foo","type":"fixed","size":15}`,
@@ -192,7 +192,7 @@ func TestSchema_JSON(t *testing.T) {
 			json:  `{"name":"foo","type":"fixed","size":12,"logicalType":"decimal","precision":4}`,
 		},
 		{
-			input: `{"namespace":"x.y.z", "type":"fixed", "name":"foo", "doc":"foo bar", "size":32}`,
+			input: `{"namespace":"x.y.z", "type":"fixed", "name":"foo", "size":32}`,
 			json:  `{"name":"x.y.z.foo","type":"fixed","size":32}`,
 		},
 		{

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -205,9 +205,13 @@ func parseRecord(typ Type, namespace string, m map[string]interface{}, cache *Sc
 	)
 	switch typ {
 	case Record:
-		rec, err = NewRecordSchema(r.Name, r.Namespace, fields, WithAliases(r.Aliases), WithDoc(r.Doc), WithProps(r.Props))
+		rec, err = NewRecordSchema(r.Name, r.Namespace, fields,
+			WithAliases(r.Aliases), WithDoc(r.Doc), WithProps(r.Props),
+		)
 	case Error:
-		rec, err = NewErrorRecordSchema(r.Name, r.Namespace, fields, WithAliases(r.Aliases), WithDoc(r.Doc), WithProps(r.Props))
+		rec, err = NewErrorRecordSchema(r.Name, r.Namespace, fields,
+			WithAliases(r.Aliases), WithDoc(r.Doc), WithProps(r.Props),
+		)
 	}
 	if err != nil {
 		return nil, err
@@ -236,7 +240,7 @@ type fieldSchema struct {
 	Type    interface{}            `mapstructure:"type"`
 	Doc     string                 `mapstructure:"doc"`
 	Default interface{}            `mapstructure:"default"`
-	Order   string                 `mapstructure:"order"`
+	Order   Order                  `mapstructure:"order"`
 	Props   map[string]interface{} `mapstructure:",remain"`
 }
 
@@ -265,7 +269,9 @@ func parseField(namespace string, m map[string]interface{}, cache *SchemaCache) 
 		f.Default = NoDefault
 	}
 
-	field, err := NewField(f.Name, typ, WithDefault(f.Default), WithAliases(f.Aliases), WithDoc(f.Doc), WithOrder(f.Order), WithProps(f.Props))
+	field, err := NewField(f.Name, typ,
+		WithDefault(f.Default), WithAliases(f.Aliases), WithDoc(f.Doc), WithOrder(f.Order), WithProps(f.Props),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +306,9 @@ func parseEnum(namespace string, m map[string]interface{}, cache *SchemaCache) (
 		e.Namespace = namespace
 	}
 
-	enum, err := NewEnumSchema(e.Name, e.Namespace, e.Symbols, WithDefault(e.Default), WithAliases(e.Aliases), WithDoc(e.Doc), WithProps(e.Props))
+	enum, err := NewEnumSchema(e.Name, e.Namespace, e.Symbols,
+		WithDefault(e.Default), WithAliases(e.Aliases), WithDoc(e.Doc), WithProps(e.Props),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -9,14 +9,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
-)
-
-var (
-	schemaReserved = []string{
-		"doc", "fields", "items", "name", "namespace", "size", "symbols",
-		"values", "type", "aliases", "logicalType", "precision", "scale",
-	}
-	fieldReserved = []string{"default", "doc", "name", "order", "type", "aliases"}
+	"github.com/mitchellh/mapstructure"
 )
 
 // DefaultSchemaCache is the default cache for schemas.
@@ -175,162 +168,199 @@ func parsePrimitiveLogicalType(typ Type, m map[string]interface{}) LogicalSchema
 	return nil
 }
 
+type recordSchema struct {
+	Type      string                   `mapstructure:"type"`
+	Name      string                   `mapstructure:"name"`
+	Namespace string                   `mapstructure:"namespace"`
+	Aliases   []string                 `mapstructure:"aliases"`
+	Doc       string                   `mapstructure:"doc"`
+	Fields    []map[string]interface{} `mapstructure:"fields"`
+	Props     map[string]interface{}   `mapstructure:",remain"`
+}
+
 func parseRecord(typ Type, namespace string, m map[string]interface{}, cache *SchemaCache) (Schema, error) {
-	name, newNamespace, err := resolveFullName(m)
-	if err != nil {
-		return nil, err
-	}
-	if newNamespace != "" {
-		namespace = newNamespace
+	var (
+		r    recordSchema
+		meta mapstructure.Metadata
+	)
+	if err := decodeMap(m, &r, &meta); err != nil {
+		return nil, fmt.Errorf("avro: error decoding record: %w", err)
 	}
 
-	fs, ok := m["fields"].([]interface{})
-	if !ok {
+	if err := checkParsedName(r.Name, r.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
+		return nil, err
+	}
+	if r.Namespace == "" {
+		r.Namespace = namespace
+	}
+
+	if !hasKey(meta.Keys, "fields") {
 		return nil, errors.New("avro: record must have an array of fields")
 	}
-	fields := make([]*Field, len(fs))
+	fields := make([]*Field, len(r.Fields))
 
-	var rec *RecordSchema
+	var (
+		rec *RecordSchema
+		err error
+	)
 	switch typ {
 	case Record:
-		rec, err = NewRecordSchema(name, namespace, fields)
+		rec, err = NewRecordSchema(r.Name, r.Namespace, fields, WithAliases(r.Aliases), WithDoc(r.Doc), WithProps(r.Props))
 	case Error:
-		rec, err = NewErrorRecordSchema(name, namespace, fields)
+		rec, err = NewErrorRecordSchema(r.Name, r.Namespace, fields, WithAliases(r.Aliases), WithDoc(r.Doc), WithProps(r.Props))
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	cache.Add(rec.FullName(), NewRefSchema(rec))
-
-	for k, v := range m {
-		rec.AddProp(k, v)
+	ref := NewRefSchema(rec)
+	cache.Add(rec.FullName(), ref)
+	for _, alias := range rec.Aliases() {
+		cache.Add(alias, ref)
 	}
 
-	for i, f := range fs {
-		field, err := parseField(namespace, f, cache)
+	for i, f := range r.Fields {
+		field, err := parseField(r.Namespace, f, cache)
 		if err != nil {
 			return nil, err
 		}
-
 		fields[i] = field
 	}
 
 	return rec, nil
 }
 
-func parseField(namespace string, v interface{}, cache *SchemaCache) (*Field, error) {
-	m, ok := v.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("avro: invalid field: %+v", v)
+type fieldSchema struct {
+	Name    string                 `mapstructure:"name"`
+	Aliases []string               `mapstructure:"aliases"`
+	Type    interface{}            `mapstructure:"type"`
+	Doc     string                 `mapstructure:"doc"`
+	Default interface{}            `mapstructure:"default"`
+	Order   string                 `mapstructure:"order"`
+	Props   map[string]interface{} `mapstructure:",remain"`
+}
+
+func parseField(namespace string, m map[string]interface{}, cache *SchemaCache) (*Field, error) {
+	var (
+		f    fieldSchema
+		meta mapstructure.Metadata
+	)
+	if err := decodeMap(m, &f, &meta); err != nil {
+		return nil, fmt.Errorf("avro: error decoding field: %w", err)
 	}
 
-	name, err := resolveName(m)
-	if err != nil {
+	if err := checkParsedName(f.Name, "", false); err != nil {
 		return nil, err
 	}
 
-	if _, ok := m["type"]; !ok {
+	if !hasKey(meta.Keys, "type") {
 		return nil, errors.New("avro: field requires a type")
 	}
-	typ, err := parseType(namespace, m["type"], cache)
+	typ, err := parseType(namespace, f.Type, cache)
 	if err != nil {
 		return nil, err
 	}
 
-	def, ok := m["default"]
-	if !ok {
-		def = NoDefault
+	if !hasKey(meta.Keys, "default") {
+		f.Default = NoDefault
 	}
 
-	field, err := NewField(name, typ, def)
+	field, err := NewField(f.Name, typ, WithDefault(f.Default), WithAliases(f.Aliases), WithDoc(f.Doc), WithOrder(f.Order), WithProps(f.Props))
 	if err != nil {
 		return nil, err
-	}
-
-	for k, v := range m {
-		field.AddProp(k, v)
 	}
 
 	return field, nil
 }
 
+type enumSchema struct {
+	Name      string                 `mapstructure:"name"`
+	Namespace string                 `mapstructure:"namespace"`
+	Aliases   []string               `mapstructure:"aliases"`
+	Type      string                 `mapstructure:"type"`
+	Doc       string                 `mapstructure:"doc"`
+	Symbols   []string               `mapstructure:"symbols"`
+	Default   string                 `mapstructure:"default"`
+	Props     map[string]interface{} `mapstructure:",remain"`
+}
+
 func parseEnum(namespace string, m map[string]interface{}, cache *SchemaCache) (Schema, error) {
-	name, newNamespace, err := resolveFullName(m)
-	if err != nil {
+	var (
+		e    enumSchema
+		meta mapstructure.Metadata
+	)
+	if err := decodeMap(m, &e, &meta); err != nil {
+		return nil, fmt.Errorf("avro: error decoding enum: %w", err)
+	}
+
+	if err := checkParsedName(e.Name, e.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
 		return nil, err
 	}
-	if newNamespace != "" {
-		namespace = newNamespace
+	if e.Namespace == "" {
+		e.Namespace = namespace
 	}
 
-	syms, ok := m["symbols"].([]interface{})
-	if !ok {
-		return nil, errors.New("avro: enum must have a non-empty array of symbols")
-	}
-
-	symbols := make([]string, len(syms))
-	for i, sym := range syms {
-		str, ok := sym.(string)
-		if !ok {
-			return nil, fmt.Errorf("avro: invalid symbol: %+v", sym)
-		}
-
-		symbols[i] = str
-	}
-
-	enum, err := NewEnumSchema(name, namespace, symbols)
+	enum, err := NewEnumSchema(e.Name, e.Namespace, e.Symbols, WithDefault(e.Default), WithAliases(e.Aliases), WithDoc(e.Doc), WithProps(e.Props))
 	if err != nil {
 		return nil, err
 	}
 
 	cache.Add(enum.FullName(), enum)
-
-	for k, v := range m {
-		enum.AddProp(k, v)
+	for _, alias := range enum.Aliases() {
+		cache.Add(alias, enum)
 	}
 
 	return enum, nil
 }
 
+type arraySchema struct {
+	Items interface{}            `mapstructure:"items"`
+	Props map[string]interface{} `mapstructure:",remain"`
+}
+
 func parseArray(namespace string, m map[string]interface{}, cache *SchemaCache) (Schema, error) {
-	items, ok := m["items"]
-	if !ok {
-		return nil, errors.New("avro: array must have an items key")
+	var (
+		a    arraySchema
+		meta mapstructure.Metadata
+	)
+	if err := decodeMap(m, &a, &meta); err != nil {
+		return nil, fmt.Errorf("avro: error decoding array: %w", err)
 	}
 
-	schema, err := parseType(namespace, items, cache)
+	if !hasKey(meta.Keys, "items") {
+		return nil, errors.New("avro: array must have an items key")
+	}
+	schema, err := parseType(namespace, a.Items, cache)
 	if err != nil {
 		return nil, err
 	}
 
-	arr := NewArraySchema(schema)
+	return NewArraySchema(schema, WithProps(a.Props)), nil
+}
 
-	for k, v := range m {
-		arr.AddProp(k, v)
-	}
-
-	return arr, nil
+type mapSchema struct {
+	Values interface{}            `mapstructure:"values"`
+	Props  map[string]interface{} `mapstructure:",remain"`
 }
 
 func parseMap(namespace string, m map[string]interface{}, cache *SchemaCache) (Schema, error) {
-	values, ok := m["values"]
-	if !ok {
-		return nil, errors.New("avro: map must have an values key")
+	var (
+		ms   mapSchema
+		meta mapstructure.Metadata
+	)
+	if err := decodeMap(m, &ms, &meta); err != nil {
+		return nil, fmt.Errorf("avro: error decoding map: %w", err)
 	}
 
-	schema, err := parseType(namespace, values, cache)
+	if !hasKey(meta.Keys, "values") {
+		return nil, errors.New("avro: map must have an values key")
+	}
+	schema, err := parseType(namespace, ms.Values, cache)
 	if err != nil {
 		return nil, err
 	}
 
-	ms := NewMapSchema(schema)
-
-	for k, v := range m {
-		ms.AddProp(k, v)
-	}
-
-	return ms, nil
+	return NewMapSchema(schema, WithProps(ms.Props)), nil
 }
 
 func parseUnion(namespace string, v []interface{}, cache *SchemaCache) (Schema, error) {
@@ -346,31 +376,45 @@ func parseUnion(namespace string, v []interface{}, cache *SchemaCache) (Schema, 
 	return NewUnionSchema(types)
 }
 
+type fixedSchema struct {
+	Name      string                 `mapstructure:"name"`
+	Namespace string                 `mapstructure:"namespace"`
+	Aliases   []string               `mapstructure:"aliases"`
+	Type      string                 `mapstructure:"type"`
+	Size      int                    `mapstructure:"size"`
+	Props     map[string]interface{} `mapstructure:",remain"`
+}
+
 func parseFixed(namespace string, m map[string]interface{}, cache *SchemaCache) (Schema, error) {
-	name, newNamespace, err := resolveFullName(m)
-	if err != nil {
-		return nil, err
-	}
-	if newNamespace != "" {
-		namespace = newNamespace
+	var (
+		f    fixedSchema
+		meta mapstructure.Metadata
+	)
+	if err := decodeMap(m, &f, &meta); err != nil {
+		return nil, fmt.Errorf("avro: error decoding fixed: %w", err)
 	}
 
-	size, ok := m["size"].(float64)
-	if !ok {
+	if err := checkParsedName(f.Name, f.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
+		return nil, err
+	}
+	if f.Namespace == "" {
+		f.Namespace = namespace
+	}
+
+	if !hasKey(meta.Keys, "size") {
 		return nil, errors.New("avro: fixed must have a size")
 	}
 
-	logical := parseFixedLogicalType(int(size), m)
+	logical := parseFixedLogicalType(f.Size, m)
 
-	fixed, err := NewFixedSchema(name, namespace, int(size), logical)
+	fixed, err := NewFixedSchema(f.Name, f.Namespace, f.Size, logical, WithAliases(f.Aliases), WithProps(f.Props))
 	if err != nil {
 		return nil, err
 	}
 
 	cache.Add(fixed.FullName(), fixed)
-
-	for k, v := range m {
-		fixed.AddProp(k, v)
+	for _, alias := range fixed.Aliases() {
+		cache.Add(alias, fixed)
 	}
 
 	return fixed, nil
@@ -383,11 +427,10 @@ func parseFixedLogicalType(size int, m map[string]interface{}) LogicalSchema {
 	}
 
 	ltyp := LogicalType(lt)
-	if ltyp == Duration && size == 12 {
+	switch {
+	case ltyp == Duration && size == 12:
 		return NewPrimitiveLogicalSchema(Duration)
-	}
-
-	if ltyp == Decimal {
+	case ltyp == Decimal:
 		return parseDecimalLogicalType(size, m)
 	}
 
@@ -428,28 +471,32 @@ func fullName(namespace, name string) string {
 	return namespace + "." + name
 }
 
-func resolveName(m map[string]interface{}) (string, error) {
-	name, ok := m["name"].(string)
-	if !ok {
-		return "", errors.New("avro: name key required")
+func checkParsedName(name, ns string, hasNS bool) error {
+	if name == "" {
+		return errors.New("avro: non-empty name key required")
 	}
-
-	return name, nil
+	if hasNS && ns == "" {
+		return errors.New("avro: namespace key must be non-empty or omitted")
+	}
+	return nil
 }
 
-func resolveFullName(m map[string]interface{}) (string, string, error) {
-	name, err := resolveName(m)
-	if err != nil {
-		return "", "", err
+func hasKey(keys []string, k string) bool {
+	for _, key := range keys {
+		if key == k {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeMap(in, v interface{}, meta *mapstructure.Metadata) error {
+	cfg := &mapstructure.DecoderConfig{
+		ZeroFields: true,
+		Metadata:   meta,
+		Result:     v,
 	}
 
-	namespace, ok := m["namespace"].(string)
-	if !ok {
-		return name, "", nil
-	}
-	if namespace == "" {
-		return "", "", errors.New("avro: namespace key must be non-empty or omitted")
-	}
-
-	return name, namespace, nil
+	decoder, _ := mapstructure.NewDecoder(cfg)
+	return decoder.Decode(in)
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -426,31 +426,31 @@ func TestRecordSchema_ValidatesOrder(t *testing.T) {
 	tests := []struct {
 		name    string
 		schema  string
-		want    string
+		want    avro.Order
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
 			name:    "empty",
 			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string"}]}`,
-			want:    "ascending",
+			want:    avro.Asc,
 			wantErr: assert.NoError,
 		},
 		{
 			name:    "asc",
 			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "ascending"}]}`,
-			want:    "ascending",
+			want:    avro.Asc,
 			wantErr: assert.NoError,
 		},
 		{
 			name:    "desc",
 			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "descending"}]}`,
-			want:    "descending",
+			want:    avro.Desc,
 			wantErr: assert.NoError,
 		},
 		{
 			name:    "ignore",
 			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "ignore"}]}`,
-			want:    "ignore",
+			want:    avro.Ignore,
 			wantErr: assert.NoError,
 		},
 		{

--- a/schema_test.go
+++ b/schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hamba/avro"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParse_InvalidType(t *testing.T) {
@@ -35,7 +36,7 @@ func TestMustParse_PanicsOnError(t *testing.T) {
 func TestParseFiles(t *testing.T) {
 	s, err := avro.ParseFiles("testdata/schema.avsc")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, avro.String, s.Type())
 }
 
@@ -60,7 +61,7 @@ func TestNullSchema(t *testing.T) {
 	for _, schm := range schemas {
 		schema, err := avro.Parse(schm)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, avro.Null, schema.Type())
 		want := [32]byte{0xf0, 0x72, 0xcb, 0xec, 0x3b, 0xf8, 0x84, 0x18, 0x71, 0xd4, 0x28, 0x42, 0x30, 0xc5, 0xe9, 0x83, 0xdc, 0x21, 0x1a, 0x56, 0x83, 0x7a, 0xed, 0x86, 0x24, 0x87, 0x14, 0x8f, 0x94, 0x7d, 0x1a, 0x1f}
 		assert.Equal(t, want, schema.Fingerprint())
@@ -145,13 +146,14 @@ func TestPrimitiveSchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.schema, func(t *testing.T) {
-			s, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.schema, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
 
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, s.Type())
-			assert.Equal(t, tt.wantFingerprint, s.Fingerprint())
+			require.NoError(t, err)
+			assert.Equal(t, test.want, s.Type())
+			assert.Equal(t, test.wantFingerprint, s.Fingerprint())
 		})
 	}
 }
@@ -218,6 +220,11 @@ func TestRecordSchema(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "Invalid Alias",
+			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "field", "aliases": ["test+"], "type": "int"}]}`,
+			wantErr: true,
+		},
+		{
 			name:    "No Field Type",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "field"}]}`,
 			wantErr: true,
@@ -229,16 +236,17 @@ func TestRecordSchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Record, s.Type())
 		})
 	}
@@ -287,17 +295,18 @@ func TestErrorRecordSchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
 
-			s, err := avro.Parse(tt.schema)
+			s, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Record, s.Type())
 			recSchema := s.(*avro.RecordSchema)
 			assert.True(t, recSchema.IsError())
@@ -309,110 +318,159 @@ func TestRecordSchema_ValidatesDefault(t *testing.T) {
 	tests := []struct {
 		name    string
 		schema  string
-		wantErr bool
+		wantErr assert.ErrorAssertionFunc
 	}{
 		{
 			name:    "String",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "string", "default": "test"}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Int",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "int", "default": 1}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Long",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "long", "default": 1}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Float",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "float", "default": 1}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Double",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": "double", "default": 1}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Array",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"array", "items": "int"}, "default": [1,2]}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Array Not Array",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"array", "items": "int"}, "default": "test"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Array Invalid Type",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"array", "items": "int"}, "default": ["test"]}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Map",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"map", "values": "int"}, "default": {"b": 1}}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Map Not Map",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"map", "values": "int"}, "default": "test"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Map Invalid Type",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"map", "values": "int"}, "default": {"b": "test"}}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Union",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": ["string", "null"]}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Default",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": ["null", "string"], "default": null}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Union Invalid Type",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": ["null", "string"], "default": "string"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Record",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"record", "name": "test2", "fields":[{"name": "b", "type": "int"},{"name": "c", "type": "int", "default": 1}]}, "default": {"b": 1}}]}`,
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
 			name:    "Record Not Map",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"record", "name": "test2", "fields":[{"name": "b", "type": "int"},{"name": "c", "type": "int", "default": 1}]}, "default": "test"}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Record Invalid Type",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"record", "name": "test2", "fields":[{"name": "b", "type": "int"},{"name": "c", "type": "int", "default": 1}]}, "default": {"b": "test"}}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
 			name:    "Record Invalid Field Type",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": {"type":"record", "name": "test2", "fields":[{"name": "b", "type": "int"},{"name": "c", "type": "int", "default": "test"}]}, "default": {"b": 1}}]}`,
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
+			test.wantErr(t, err)
+		})
+	}
+}
+
+func TestRecordSchema_ValidatesOrder(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  string
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "empty",
+			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string"}]}`,
+			want:    "ascending",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "asc",
+			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "ascending"}]}`,
+			want:    "ascending",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "desc",
+			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "descending"}]}`,
+			want:    "descending",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "ignore",
+			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "ignore"}]}`,
+			want:    "ignore",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "invalid",
+			schema:  `{"type":"record", "name":"test", "fields":[{"name": "a", "type": "string", "order": "blah"}]}`,
+			wantErr: assert.Error,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
+
+			test.wantErr(t, err)
+			if s != nil {
+				rs := s.(*avro.RecordSchema)
+				require.Len(t, rs.Fields(), 1)
+				assert.Equal(t, test.want, rs.Fields()[0].Order())
 			}
-
-			assert.NoError(t, err)
 		})
 	}
 }
@@ -423,19 +481,24 @@ func TestRecordSchema_HandlesProps(t *testing.T) {
    "type": "record",
    "name": "valid_name",
    "namespace": "org.hamba.avro",
+   "doc": "foo",
    "foo": "bar1",
    "fields": [
-       {"name": "intField", "type": "int", "foo": "bar2"}
+       {"name": "intField", "doc": "bar", "type": "int", "foo": "bar2"}
    ]
 }
 `
 
 	s, err := avro.Parse(schm)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
+	rs := s.(*avro.RecordSchema)
 	assert.Equal(t, avro.Record, s.Type())
-	assert.Equal(t, "bar1", s.(*avro.RecordSchema).Prop("foo"))
-	assert.Equal(t, "bar2", s.(*avro.RecordSchema).Fields()[0].Prop("foo"))
+	assert.Equal(t, "foo", rs.Doc())
+	assert.Equal(t, "bar1", rs.Prop("foo"))
+	require.Len(t, rs.Fields(), 1)
+	assert.Equal(t, "bar", rs.Fields()[0].Doc())
+	assert.Equal(t, "bar2", rs.Fields()[0].Prop("foo"))
 }
 
 func TestRecordSchema_WithReference(t *testing.T) {
@@ -453,7 +516,29 @@ func TestRecordSchema_WithReference(t *testing.T) {
 
 	s, err := avro.Parse(schm)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, avro.Record, s.Type())
+	assert.Equal(t, avro.Ref, s.(*avro.RecordSchema).Fields()[1].Type().Type())
+	assert.Equal(t, s.Fingerprint(), s.(*avro.RecordSchema).Fields()[1].Type().Fingerprint())
+}
+
+func TestRecordSchema_WithAliasReference(t *testing.T) {
+	schm := `
+{
+   "type": "record",
+   "name": "valid_name",
+   "namespace": "org.hamba.avro",
+   "aliases": ["valid_alias"],
+   "fields": [
+       {"name": "intField", "type": "int"},
+       {"name": "ref", "type": "valid_alias"}
+   ]
+}
+`
+
+	s, err := avro.Parse(schm)
+
+	require.NoError(t, err)
 	assert.Equal(t, avro.Record, s.Type())
 	assert.Equal(t, avro.Ref, s.(*avro.RecordSchema).Fields()[1].Type().Type())
 	assert.Equal(t, s.Fingerprint(), s.(*avro.RecordSchema).Fields()[1].Type().Fingerprint())
@@ -461,16 +546,24 @@ func TestRecordSchema_WithReference(t *testing.T) {
 
 func TestEnumSchema(t *testing.T) {
 	tests := []struct {
-		name     string
-		schema   string
-		wantName string
-		wantErr  bool
+		name        string
+		schema      string
+		wantName    string
+		wantDefault string
+		wantErr     bool
 	}{
 		{
 			name:     "Valid",
 			schema:   `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST"]}`,
 			wantName: "org.hamba.avro.test",
 			wantErr:  false,
+		},
+		{
+			name:        "Valid With Default",
+			schema:      `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST"], "default": "TEST"}`,
+			wantName:    "org.hamba.avro.test",
+			wantDefault: "TEST",
+			wantErr:     false,
 		},
 		{
 			name:    "Invalid Name",
@@ -517,33 +610,42 @@ func TestEnumSchema(t *testing.T) {
 			schema:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":[1]}`,
 			wantErr: true,
 		},
+		{
+			name:    "Invalid Default",
+			schema:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST"], "default": "foo"}`,
+			wantErr: true,
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			schema, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			schema, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Enum, schema.Type())
-			named := schema.(avro.NamedSchema)
-			assert.Equal(t, tt.wantName, named.FullName())
+			named := schema.(*avro.EnumSchema)
+			assert.Equal(t, test.wantName, named.FullName())
+			assert.Equal(t, test.wantDefault, named.Default())
 		})
 	}
 }
 
 func TestEnumSchema_HandlesProps(t *testing.T) {
-	schm := `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST"], "foo":"bar"}`
+	schm := `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "doc": "hello", "symbols":["TEST"], "foo":"bar"}`
 
 	s, err := avro.Parse(schm)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
+	es := s.(*avro.EnumSchema)
 	assert.Equal(t, avro.Enum, s.Type())
-	assert.Equal(t, "bar", s.(*avro.EnumSchema).Prop("foo"))
+	assert.Equal(t, "hello", es.Doc())
+	assert.Equal(t, "bar", es.Prop("foo"))
 }
 
 func TestArraySchema(t *testing.T) {
@@ -569,16 +671,17 @@ func TestArraySchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Array, s.Type())
 		})
 	}
@@ -589,7 +692,7 @@ func TestArraySchema_HandlesProps(t *testing.T) {
 
 	s, err := avro.Parse(schm)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, avro.Array, s.Type())
 	assert.Equal(t, "bar", s.(*avro.ArraySchema).Prop("foo"))
 }
@@ -617,16 +720,17 @@ func TestMapSchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Map, s.Type())
 		})
 	}
@@ -637,7 +741,7 @@ func TestMapSchema_HandlesProps(t *testing.T) {
 
 	s, err := avro.Parse(schm)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, avro.Map, s.Type())
 	assert.Equal(t, "bar", s.(*avro.MapSchema).Prop("foo"))
 }
@@ -662,10 +766,10 @@ func TestUnionSchema(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name:    "Dereferences Ref Schemas",
-			schema:  `[{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}, {"type":"enum", "name":"test1", "namespace": "org.hamba.avro", "symbols":["TEST"]}, {"type":"record", "name":"test2", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": ["null","org.hamba.avro.test","org.hamba.avro.test1"]}]}]`,
+			name:            "Dereferences Ref Schemas",
+			schema:          `[{"type":"fixed", "name":"test", "namespace": "org.hamba.avro", "size": 12}, {"type":"enum", "name":"test1", "namespace": "org.hamba.avro", "symbols":["TEST"]}, {"type":"record", "name":"test2", "namespace": "org.hamba.avro", "fields":[{"name": "a", "type": ["null","org.hamba.avro.test","org.hamba.avro.test1"]}]}]`,
 			wantFingerprint: [32]byte{0xc1, 0x42, 0x87, 0xde, 0x24, 0x3d, 0xee, 0x1d, 0xa5, 0x47, 0xa0, 0x13, 0x9e, 0xb, 0xe0, 0x6, 0xfd, 0xa, 0x76, 0xd9, 0xe8, 0x92, 0x9a, 0xd3, 0x46, 0xf, 0xbd, 0x86, 0x21, 0x72, 0x81, 0x1b},
-			wantErr: false,
+			wantErr:         false,
 		},
 		{
 			name:    "No Nested Union Type",
@@ -689,18 +793,19 @@ func TestUnionSchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Union, s.Type())
-			assert.Equal(t, tt.wantFingerprint, s.Fingerprint())
+			assert.Equal(t, test.wantFingerprint, s.Fingerprint())
 		})
 	}
 }
@@ -728,14 +833,15 @@ func TestUnionSchema_Indices(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			s, err := avro.Parse(test.schema)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			null, typ := s.(*avro.UnionSchema).Indices()
-			assert.Equal(t, tt.want[0], null)
-			assert.Equal(t, tt.want[1], typ)
+			assert.Equal(t, test.want[0], null)
+			assert.Equal(t, test.want[1], typ)
 		})
 	}
 }
@@ -792,20 +898,21 @@ func TestFixedSchema(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			schema, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			schema, err := avro.Parse(test.schema)
 
-			if tt.wantErr {
+			if test.wantErr {
 				assert.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, avro.Fixed, schema.Type())
 			named := schema.(avro.NamedSchema)
-			assert.Equal(t, tt.wantName, named.FullName())
-			assert.Equal(t, tt.wantFingerprint, named.Fingerprint())
+			assert.Equal(t, test.wantName, named.FullName())
+			assert.Equal(t, test.wantFingerprint, named.Fingerprint())
 		})
 	}
 }
@@ -815,7 +922,7 @@ func TestFixedSchema_HandlesProps(t *testing.T) {
 
 	s, err := avro.Parse(schm)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, avro.Fixed, s.Type())
 	assert.Equal(t, "bar", s.(*avro.FixedSchema).Prop("foo"))
 }
@@ -898,10 +1005,9 @@ func TestSchema_LogicalTypes(t *testing.T) {
 			wantLogicalType: avro.Decimal,
 			assertFn: func(t *testing.T, ls avro.LogicalSchema) {
 				dec, ok := ls.(*avro.DecimalLogicalSchema)
-				if assert.True(t, ok) {
-					assert.Equal(t, 4, dec.Precision())
-					assert.Equal(t, 2, dec.Scale())
-				}
+				require.True(t, ok)
+				assert.Equal(t, 4, dec.Precision())
+				assert.Equal(t, 2, dec.Scale())
 			},
 		},
 		{
@@ -912,10 +1018,9 @@ func TestSchema_LogicalTypes(t *testing.T) {
 			wantLogicalType: avro.Decimal,
 			assertFn: func(t *testing.T, ls avro.LogicalSchema) {
 				dec, ok := ls.(*avro.DecimalLogicalSchema)
-				if assert.True(t, ok) {
-					assert.Equal(t, 4, dec.Precision())
-					assert.Equal(t, 0, dec.Scale())
-				}
+				require.True(t, ok)
+				assert.Equal(t, 4, dec.Precision())
+				assert.Equal(t, 0, dec.Scale())
 			},
 		},
 		{
@@ -944,10 +1049,9 @@ func TestSchema_LogicalTypes(t *testing.T) {
 			wantLogicalType: avro.Decimal,
 			assertFn: func(t *testing.T, ls avro.LogicalSchema) {
 				dec, ok := ls.(*avro.DecimalLogicalSchema)
-				if assert.True(t, ok) {
-					assert.Equal(t, 4, dec.Precision())
-					assert.Equal(t, 2, dec.Scale())
-				}
+				require.True(t, ok)
+				assert.Equal(t, 4, dec.Precision())
+				assert.Equal(t, 2, dec.Scale())
 			},
 		},
 		{
@@ -958,10 +1062,9 @@ func TestSchema_LogicalTypes(t *testing.T) {
 			wantLogicalType: avro.Decimal,
 			assertFn: func(t *testing.T, ls avro.LogicalSchema) {
 				dec, ok := ls.(*avro.DecimalLogicalSchema)
-				if assert.True(t, ok) {
-					assert.Equal(t, 4, dec.Precision())
-					assert.Equal(t, 0, dec.Scale())
-				}
+				require.True(t, ok)
+				assert.Equal(t, 4, dec.Precision())
+				assert.Equal(t, 0, dec.Scale())
 			},
 		},
 		{
@@ -984,12 +1087,13 @@ func TestSchema_LogicalTypes(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			schema, err := avro.Parse(tt.schema)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			schema, err := avro.Parse(test.schema)
 
-			assert.NoError(t, err)
-			assert.Equal(t, tt.wantType, schema.Type())
+			require.NoError(t, err)
+			assert.Equal(t, test.wantType, schema.Type())
 
 			lts, ok := schema.(avro.LogicalTypeSchema)
 			if !ok {
@@ -998,16 +1102,15 @@ func TestSchema_LogicalTypes(t *testing.T) {
 			}
 
 			ls := lts.Logical()
-			if assert.Equal(t, tt.wantLogical, ls != nil) {
-				if !tt.wantLogical {
-					return
-				}
+			require.Equal(t, test.wantLogical, ls != nil)
+			if !test.wantLogical {
+				return
+			}
 
-				assert.Equal(t, tt.wantLogicalType, ls.Type())
+			assert.Equal(t, test.wantLogicalType, ls.Type())
 
-				if tt.assertFn != nil {
-					tt.assertFn(t, ls)
-				}
+			if test.assertFn != nil {
+				test.assertFn(t, ls)
 			}
 		})
 	}
@@ -1083,14 +1186,14 @@ func TestSchema_FingerprintUsing(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			schema := avro.MustParse(tt.schema)
-			got, err := schema.FingerprintUsing(tt.typ)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			schema := avro.MustParse(test.schema)
+			got, err := schema.FingerprintUsing(test.typ)
 
-			if assert.NoError(t, err) {
-				assert.Equal(t, tt.want, got)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
 		})
 	}
 }
@@ -1110,7 +1213,7 @@ func TestSchema_FingerprintUsingReference(t *testing.T) {
 
 	got, err := schema.(*avro.RecordSchema).Fields()[1].Type().FingerprintUsing(avro.CRC64Avro)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte{0xe1, 0xd6, 0x1e, 0x7c, 0x2f, 0xe3, 0x3c, 0x2b}, got)
 }
 


### PR DESCRIPTION
This reworks the schema parsing. In the process aliases are now supported and json serialisation of schemas is greatly improved.