### PR TITLE
Expose record and field doc

### DIFF
--- a/protocol_test.go
+++ b/protocol_test.go
@@ -26,9 +26,9 @@ func TestNewProtocol_ValidatesName(t *testing.T) {
 }
 
 func TestNewMessage(t *testing.T) {
-	field, _ := avro.NewField("test", avro.NewPrimitiveSchema(avro.String, nil), nil)
+	field, _ := avro.NewField("test", avro.NewPrimitiveSchema(avro.String, nil), "", nil)
 	fields := []*avro.Field{field}
-	req, _ := avro.NewRecordSchema("test", "", fields)
+	req, _ := avro.NewRecordSchema("test", "", "", fields)
 	resp := avro.NewPrimitiveSchema(avro.String, nil)
 	types := []avro.Schema{avro.NewPrimitiveSchema(avro.String, nil)}
 	errs, _ := avro.NewUnionSchema(types)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -26,9 +26,9 @@ func TestNewProtocol_ValidatesName(t *testing.T) {
 }
 
 func TestNewMessage(t *testing.T) {
-	field, _ := avro.NewField("test", avro.NewPrimitiveSchema(avro.String, nil), "", nil)
+	field, _ := avro.NewField("test", avro.NewPrimitiveSchema(avro.String, nil), nil)
 	fields := []*avro.Field{field}
-	req, _ := avro.NewRecordSchema("test", "", "", fields)
+	req, _ := avro.NewRecordSchema("test", "", fields)
 	resp := avro.NewPrimitiveSchema(avro.String, nil)
 	types := []avro.Schema{avro.NewPrimitiveSchema(avro.String, nil)}
 	errs, _ := avro.NewUnionSchema(types)

--- a/schema.go
+++ b/schema.go
@@ -372,6 +372,7 @@ func (s *RecordSchema) Type() Type {
 	return Record
 }
 
+// Doc returns the documentation of a record.
 func (s *RecordSchema) Doc() string {
 	return s.doc
 }
@@ -434,7 +435,7 @@ func (s *RecordSchema) FingerprintUsing(typ FingerprintType) ([]byte, error) {
 	return s.fingerprinter.FingerprintUsing(typ, s)
 }
 
-// AddDoc add documentation to the record
+// AddDoc add documentation to the record.
 func (s *RecordSchema) AddDoc(doc string) {
 	s.doc = doc
 }
@@ -494,7 +495,7 @@ func (f *Field) HasDefault() bool {
 	return f.hasDef
 }
 
-// AddDoc add documentation to the field .
+// AddDoc add documentation to the field.
 func (f *Field) AddDoc(doc string) {
 	f.doc = doc
 }
@@ -510,7 +511,7 @@ func (f *Field) Default() interface{} {
 	return f.def
 }
 
-// Doc returns the documentation of a field
+// Doc returns the documentation of a field.
 func (f *Field) Doc() string {
 	return f.doc
 }

--- a/schema.go
+++ b/schema.go
@@ -335,10 +335,11 @@ type RecordSchema struct {
 
 	isError bool
 	fields  []*Field
+	doc     string
 }
 
 // NewRecordSchema creates a new record schema instance.
-func NewRecordSchema(name, space string, fields []*Field) (*RecordSchema, error) {
+func NewRecordSchema(name, space string, doc string, fields []*Field) (*RecordSchema, error) {
 	n, err := newName(name, space)
 	if err != nil {
 		return nil, err
@@ -346,13 +347,14 @@ func NewRecordSchema(name, space string, fields []*Field) (*RecordSchema, error)
 
 	return &RecordSchema{
 		name:       n,
+		doc:        doc,
 		properties: properties{reserved: schemaReserved},
 		fields:     fields,
 	}, nil
 }
 
 // NewErrorRecordSchema creates a new error record schema instance.
-func NewErrorRecordSchema(name, space string, fields []*Field) (*RecordSchema, error) {
+func NewErrorRecordSchema(name, space string, doc string, fields []*Field) (*RecordSchema, error) {
 	n, err := newName(name, space)
 	if err != nil {
 		return nil, err
@@ -360,6 +362,7 @@ func NewErrorRecordSchema(name, space string, fields []*Field) (*RecordSchema, e
 
 	return &RecordSchema{
 		name:       n,
+		doc:        doc,
 		properties: properties{reserved: schemaReserved},
 		isError:    true,
 		fields:     fields,
@@ -369,6 +372,10 @@ func NewErrorRecordSchema(name, space string, fields []*Field) (*RecordSchema, e
 // Type returns the type of the schema.
 func (s *RecordSchema) Type() Type {
 	return Record
+}
+
+func (s *RecordSchema) Doc() string {
+	return s.doc
 }
 
 // IsError determines is this is an error record.
@@ -434,6 +441,7 @@ type Field struct {
 	properties
 
 	name   string
+	doc    string
 	typ    Schema
 	hasDef bool
 	def    interface{}
@@ -445,7 +453,7 @@ type noDef struct{}
 var NoDefault = noDef{}
 
 // NewField creates a new field instance.
-func NewField(name string, typ Schema, def interface{}) (*Field, error) {
+func NewField(name string, typ Schema, doc string, def interface{}) (*Field, error) {
 	if err := validateName(name); err != nil {
 		return nil, err
 	}
@@ -454,6 +462,7 @@ func NewField(name string, typ Schema, def interface{}) (*Field, error) {
 		properties: properties{reserved: fieldReserved},
 		name:       name,
 		typ:        typ,
+		doc:        doc,
 	}
 
 	if def != NoDefault {
@@ -492,6 +501,11 @@ func (f *Field) Default() interface{} {
 	}
 
 	return f.def
+}
+
+// Doc returns the documentation of a field
+func (f *Field) Doc() string {
+	return f.doc
 }
 
 // String returns the canonical form of a field.

--- a/schema.go
+++ b/schema.go
@@ -339,7 +339,7 @@ type RecordSchema struct {
 }
 
 // NewRecordSchema creates a new record schema instance.
-func NewRecordSchema(name, space string, doc string, fields []*Field) (*RecordSchema, error) {
+func NewRecordSchema(name, space string, fields []*Field) (*RecordSchema, error) {
 	n, err := newName(name, space)
 	if err != nil {
 		return nil, err
@@ -347,14 +347,13 @@ func NewRecordSchema(name, space string, doc string, fields []*Field) (*RecordSc
 
 	return &RecordSchema{
 		name:       n,
-		doc:        doc,
 		properties: properties{reserved: schemaReserved},
 		fields:     fields,
 	}, nil
 }
 
 // NewErrorRecordSchema creates a new error record schema instance.
-func NewErrorRecordSchema(name, space string, doc string, fields []*Field) (*RecordSchema, error) {
+func NewErrorRecordSchema(name, space string, fields []*Field) (*RecordSchema, error) {
 	n, err := newName(name, space)
 	if err != nil {
 		return nil, err
@@ -362,7 +361,6 @@ func NewErrorRecordSchema(name, space string, doc string, fields []*Field) (*Rec
 
 	return &RecordSchema{
 		name:       n,
-		doc:        doc,
 		properties: properties{reserved: schemaReserved},
 		isError:    true,
 		fields:     fields,
@@ -436,6 +434,11 @@ func (s *RecordSchema) FingerprintUsing(typ FingerprintType) ([]byte, error) {
 	return s.fingerprinter.FingerprintUsing(typ, s)
 }
 
+// AddDoc add documentation to the record
+func (s *RecordSchema) AddDoc(doc string) {
+	s.doc = doc
+}
+
 // Field is an Avro record type field.
 type Field struct {
 	properties
@@ -453,7 +456,7 @@ type noDef struct{}
 var NoDefault = noDef{}
 
 // NewField creates a new field instance.
-func NewField(name string, typ Schema, doc string, def interface{}) (*Field, error) {
+func NewField(name string, typ Schema, def interface{}) (*Field, error) {
 	if err := validateName(name); err != nil {
 		return nil, err
 	}
@@ -462,7 +465,6 @@ func NewField(name string, typ Schema, doc string, def interface{}) (*Field, err
 		properties: properties{reserved: fieldReserved},
 		name:       name,
 		typ:        typ,
-		doc:        doc,
 	}
 
 	if def != NoDefault {
@@ -490,6 +492,11 @@ func (f *Field) Type() Schema {
 // HasDefault determines if the field has a default value.
 func (f *Field) HasDefault() bool {
 	return f.hasDef
+}
+
+// AddDoc add documentation to the field .
+func (f *Field) AddDoc(doc string) {
+	f.doc = doc
 }
 
 // Default returns the default of a field or nil.

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -184,6 +184,11 @@ func parseRecord(typ Type, namespace string, m map[string]interface{}, cache *Sc
 		namespace = newNamespace
 	}
 
+	doc, err := resolveDoc(m)
+	if err != nil {
+		return nil, err
+	}
+
 	fs, ok := m["fields"].([]interface{})
 	if !ok {
 		return nil, errors.New("avro: record must have an array of fields")
@@ -193,9 +198,9 @@ func parseRecord(typ Type, namespace string, m map[string]interface{}, cache *Sc
 	var rec *RecordSchema
 	switch typ {
 	case Record:
-		rec, err = NewRecordSchema(name, namespace, fields)
+		rec, err = NewRecordSchema(name, namespace, doc, fields)
 	case Error:
-		rec, err = NewErrorRecordSchema(name, namespace, fields)
+		rec, err = NewErrorRecordSchema(name, namespace, doc, fields)
 	}
 	if err != nil {
 		return nil, err
@@ -238,12 +243,17 @@ func parseField(namespace string, v interface{}, cache *SchemaCache) (*Field, er
 		return nil, err
 	}
 
+	doc, err := resolveDoc(m)
+	if err != nil {
+		return nil, err
+	}
+
 	def, ok := m["default"]
 	if !ok {
 		def = NoDefault
 	}
 
-	field, err := NewField(name, typ, def)
+	field, err := NewField(name, typ, doc, def)
 	if err != nil {
 		return nil, err
 	}
@@ -434,6 +444,14 @@ func resolveName(m map[string]interface{}) (string, error) {
 		return "", errors.New("avro: name key required")
 	}
 
+	return name, nil
+}
+
+func resolveDoc(m map[string]interface{}) (string, error) {
+	name, ok := m["doc"].(string)
+	if !ok {
+		return "", nil
+	}
 	return name, nil
 }
 

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -201,10 +201,7 @@ func parseRecord(typ Type, namespace string, m map[string]interface{}, cache *Sc
 		return nil, err
 	}
 
-	doc, err := resolveDoc(m)
-	if err != nil {
-		return nil, err
-	}
+	doc := resolveDoc(m)
 	rec.AddDoc(doc)
 
 	cache.Add(rec.FullName(), NewRefSchema(rec))
@@ -254,10 +251,7 @@ func parseField(namespace string, v interface{}, cache *SchemaCache) (*Field, er
 		return nil, err
 	}
 
-	doc, err := resolveDoc(m)
-	if err != nil {
-		return nil, err
-	}
+	doc := resolveDoc(m)
 	field.AddDoc(doc)
 
 	for k, v := range m {
@@ -449,12 +443,12 @@ func resolveName(m map[string]interface{}) (string, error) {
 	return name, nil
 }
 
-func resolveDoc(m map[string]interface{}) (string, error) {
+func resolveDoc(m map[string]interface{}) string {
 	doc, ok := m["doc"].(string)
 	if !ok {
-		return "", nil
+		return ""
 	}
-	return doc, nil
+	return doc
 }
 
 func resolveFullName(m map[string]interface{}) (string, string, error) {

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -205,7 +205,6 @@ func parseRecord(typ Type, namespace string, m map[string]interface{}, cache *Sc
 	if err != nil {
 		return nil, err
 	}
-
 	rec.AddDoc(doc)
 
 	cache.Add(rec.FullName(), NewRefSchema(rec))

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -452,7 +452,7 @@ func resolveName(m map[string]interface{}) (string, error) {
 }
 
 func resolveDoc(m map[string]interface{}) (string, error) {
-	name, ok := m["doc"].(string)
+	doc, ok := m["doc"].(string)
 	if !ok {
 		return "", nil
 	}

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -454,7 +454,7 @@ func resolveDoc(m map[string]interface{}) (string, error) {
 	if !ok {
 		return "", nil
 	}
-	return name, nil
+	return doc, nil
 }
 
 func resolveFullName(m map[string]interface{}) (string, string, error) {

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -258,7 +258,6 @@ func parseField(namespace string, v interface{}, cache *SchemaCache) (*Field, er
 	if err != nil {
 		return nil, err
 	}
-
 	field.AddDoc(doc)
 
 	for k, v := range m {


### PR DESCRIPTION
## Description of the problem

I would like to use hamba to validate if a schema conforms to a given set of rules.  One of this rule will check if a documentation block is present and non empty. Unfortunately, the `doc` attribute of a record/field is accessible through properties - as it is a reserved keyword - and there is no dedicated accessor.

## Proposed solution

Add a dedicated accessor to `RecordSchema` and `Field`. 

## Question 

* Would you add a dedicated test to cover this part ? I could not find a test explicitly checking accessors (for example `Name()` ?

* Would you modify an interface or create one dedicated to Doc ?