### PR TITLE
fix: null default when json marshalling unions

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -523,16 +523,23 @@ func (f *Field) String() string {
 
 // MarshalJSON marshals the schema to json.
 func (f *Field) MarshalJSON() ([]byte, error) {
-	s := struct {
-		Name    string      `json:"name"`
-		Type    Schema      `json:"type"`
-		Default interface{} `json:"default,omitempty"`
-	}{
+	type base struct {
+		Name string `json:"name"`
+		Type Schema `json:"type"`
+	}
+	type ext struct {
+		base
+		Default interface{} `json:"default"`
+	}
+	var s interface{} = base{
 		Name: f.name,
 		Type: f.typ,
 	}
 	if f.hasDef {
-		s.Default = f.def
+		s = ext{
+			base:    s.(base),
+			Default: f.Default(),
+		}
 	}
 	return jsoniter.Marshal(s)
 }

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -258,6 +258,18 @@ func TestSchema_JSON(t *testing.T) {
 			}`,
 			json: `{"name":"org.hamba.avro.X","type":"record","fields":[{"name":"value","type":{"name":"org.hamba.avro.Y","type":"fixed","size":15}}]}`,
 		},
+		{
+			input: `{
+				"type":"record",
+				"namespace": "org.hamba.avro",
+				"name":"X",
+  				"fields":[
+					{"name":"union_no_def","type":["null", "int"]},
+					{"name":"union_with_def","type":["null", "string"],"default": null}
+				]
+			}`,
+			json: `{"name":"org.hamba.avro.X","type":"record","fields":[{"name":"union_no_def","type":["null","int"]},{"name":"union_with_def","type":["null","string"],"default":null}]}`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Fixes `Field.MarshalJSON` handling of default null values. The previous implementation was relying on `omitempty` for the default field and it was not possible to differentiate between a field with no default value and one with `null`. 

Fixes #136 