### PR TITLE
Expose Write method on ocf encoder

### DIFF
--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -458,12 +458,12 @@ func TestEncoder_Write(t *testing.T) {
 	require.NoError(t, err)
 
 	err = enc.Write(encodedBytes)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = enc.Close()
 	require.NoError(t, err)
 
-	assert.Equal(t, 957, buf.Len())
+	require.Equal(t, 957, buf.Len())
 }
 
 func TestEncoder_EncodeCompressesDeflate(t *testing.T) {

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hamba/avro"
 	"github.com/hamba/avro/ocf"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var schema = `{
@@ -423,6 +425,47 @@ func TestEncoder(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestEncoder_Write(t *testing.T) {
+	unionStr := "union value"
+	record := FullRecord{
+		Strings: []string{"string1", "string2", "string3", "string4", "string5"},
+		Longs:   []int64{1, 2, 3, 4, 5},
+		Enum:    "C",
+		Map: map[string]int{
+			"key1": 1,
+			"key2": 2,
+			"key3": 3,
+			"key4": 4,
+			"key5": 5,
+		},
+		Nullable: &unionStr,
+		Fixed:    [16]byte{0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04},
+		Record: &TestRecord{
+			Long:   1925639126735,
+			String: "I am a test record",
+			Int:    666,
+			Float:  7171.17,
+			Double: 916734926348163.01973408746523,
+			Bool:   true,
+		},
+	}
+
+	buf := &bytes.Buffer{}
+	enc, err := ocf.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	encodedBytes, err := avro.Marshal(avro.MustParse(schema), record)
+	require.NoError(t, err)
+
+	err = enc.Write(encodedBytes)
+	assert.NoError(t, err)
+
+	err = enc.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, 957, buf.Len())
+}
+
 func TestEncoder_EncodeCompressesDeflate(t *testing.T) {
 	unionStr := "union value"
 	record := FullRecord{
@@ -450,7 +493,6 @@ func TestEncoder_EncodeCompressesDeflate(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	enc, _ := ocf.NewEncoder(schema, buf, ocf.WithCodec(ocf.Deflate))
-	defer enc.Close()
 
 	err := enc.Encode(record)
 	assert.NoError(t, err)


### PR DESCRIPTION
From discussion on issue https://github.com/hamba/avro/issues/142

- [x] Expose Write method on ocf encoder

Signed-off-by: Jonas Brunsgaard <jonas.brunsgaard@gmail.com>