### PR TITLE
ocf Encoder should implement writer interface

### DIFF
--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -247,19 +247,20 @@ func NewEncoder(s string, w io.Writer, opts ...EncoderFunc) (*Encoder, error) {
 // therefore the caller is responsible for encoding the bytes. No error will be
 // thrown if the bytes does not conform to the schema given to NewEncoder, but
 // the final ocf data will be corrupted.
-func (e *Encoder) Write(v []byte) error {
-	if _, err := e.buf.Write(v); err != nil {
-		return err
+func (e *Encoder) Write(p []byte) (n int, err error) {
+	n, err = e.buf.Write(p)
+	if err != nil {
+		return n, err
 	}
 
 	e.count++
 	if e.count >= e.blockLength {
 		if err := e.writerBlock(); err != nil {
-			return err
+			return n, err
 		}
 	}
 
-	return e.writer.Error
+	return n, e.writer.Error
 }
 
 // Encode writes the Avro encoding of v to the stream.

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -457,12 +457,13 @@ func TestEncoder_Write(t *testing.T) {
 	encodedBytes, err := avro.Marshal(avro.MustParse(schema), record)
 	require.NoError(t, err)
 
-	err = enc.Write(encodedBytes)
+	n, err := enc.Write(encodedBytes)
 	require.NoError(t, err)
 
 	err = enc.Close()
 	require.NoError(t, err)
 
+	require.Equal(t, n, len(encodedBytes))
 	require.Equal(t, 957, buf.Len())
 }
 


### PR DESCRIPTION
As mentioned in #142, the Write method should conform to the `io.Writer` interface

Signed-off-by: Jonas Brunsgaard <jonas.brunsgaard@gmail.com>