### PR TITLE
Schema reference support

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -238,7 +238,8 @@ func (c *Client) GetLatestSchemaInfo(subject string) (SchemaInfo, error) {
 // CreateSchema creates a schema in the registry, returning the schema id.
 func (c *Client) CreateSchema(subject, schema string, references ...SchemaReference) (int, avro.Schema, error) {
 	var payload idPayload
-	err := c.request(http.MethodPost, "/subjects/"+subject+"/versions", schemaPayload{Schema: schema, References: references}, &payload)
+	inPayload := schemaPayload{Schema: schema, References: references}
+	err := c.request(http.MethodPost, "/subjects/"+subject+"/versions", inPayload, &payload)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/registry/client.go
+++ b/registry/client.go
@@ -47,14 +47,22 @@ type Registry interface {
 	GetLatestSchemaInfo(subject string) (SchemaInfo, error)
 
 	// CreateSchema creates a schema in the registry, returning the schema id.
-	CreateSchema(subject, schema string) (int, avro.Schema, error)
+	CreateSchema(subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
 
 	// IsRegistered determines of the schema is registered.
 	IsRegistered(subject, schema string) (int, avro.Schema, error)
 }
 
 type schemaPayload struct {
-	Schema string `json:"schema"`
+	Schema     string            `json:"schema"`
+	References []SchemaReference `json:"references,omitempty"`
+}
+
+// SchemaReference represents a schema reference.
+type SchemaReference struct {
+	Name    string `json:"name"`
+	Subject string `json:"subject"`
+	Version int    `json:"version"`
 }
 
 type idPayload struct {
@@ -228,9 +236,9 @@ func (c *Client) GetLatestSchemaInfo(subject string) (SchemaInfo, error) {
 }
 
 // CreateSchema creates a schema in the registry, returning the schema id.
-func (c *Client) CreateSchema(subject, schema string) (int, avro.Schema, error) {
+func (c *Client) CreateSchema(subject, schema string, references ...SchemaReference) (int, avro.Schema, error) {
 	var payload idPayload
-	err := c.request(http.MethodPost, "/subjects/"+subject+"/versions", schemaPayload{Schema: schema}, &payload)
+	err := c.request(http.MethodPost, "/subjects/"+subject+"/versions", schemaPayload{Schema: schema, References: references}, &payload)
 	if err != nil {
 		return 0, nil, err
 	}


### PR DESCRIPTION
Now there is a way to use schemas with references
https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--subjects-(string-%20subject)-versions
https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#referenced-schemas

```go
const HeaderScheme = `
{
	"type": "record",
	"name": "eventHeader",
	"namespace": "schema",
	"fields": [
		{ "name": "eventId", "type": "string" }, 
		{ "name": "correlationId", "type": "string" },
		{ "name": "created", "type": "string" }
	]
}`

const EmployeeCreatedAvroScheme = `
{
	"type": "record",
	"name": "boEmployeeCreated",
	"namespace": "schema",
	"fields": [
		{ "name": "header", "type": "schema.eventHeader"},
		{ "name": "userId", "type": "string" }
	]
}`
```

1. Register `HeaderScheme`
```go
registry.CreateSchema(headerSubject, HeaderScheme)
```
2. Register `EmployeeCreatedAvroScheme` that have reference to `HeaderScheme`
```go

registry.CreateSchema(subject, EmployeeCreatedAvroScheme, registry.SchemaReference{
	Name:    "schema.eventHeader",
	Subject: headerSubject,
	Version: version,
})
```
