### PR TITLE
feat: add support for properties on PrimitiveSchema

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -279,6 +279,7 @@ func (p *properties) Prop(name string) interface{} {
 
 // PrimitiveSchema is an Avro primitive type schema.
 type PrimitiveSchema struct {
+	properties
 	fingerprinter
 
 	typ     Type
@@ -288,8 +289,9 @@ type PrimitiveSchema struct {
 // NewPrimitiveSchema creates a new PrimitiveSchema.
 func NewPrimitiveSchema(t Type, l LogicalSchema) *PrimitiveSchema {
 	return &PrimitiveSchema{
-		typ:     t,
-		logical: l,
+		properties: properties{reserved: schemaReserved},
+		typ:        t,
+		logical:    l,
 	}
 }
 

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -145,7 +145,13 @@ func parseComplexType(namespace string, m map[string]interface{}, cache *SchemaC
 func parsePrimitive(typ Type, m map[string]interface{}) (Schema, error) {
 	logical := parsePrimitiveLogicalType(typ, m)
 
-	return NewPrimitiveSchema(typ, logical), nil
+	prim := NewPrimitiveSchema(typ, logical)
+
+	for k, v := range m {
+		prim.AddProp(k, v)
+	}
+
+	return prim, nil
 }
 
 func parsePrimitiveLogicalType(typ Type, m map[string]interface{}) LogicalSchema {

--- a/schema_test.go
+++ b/schema_test.go
@@ -156,6 +156,23 @@ func TestPrimitiveSchema(t *testing.T) {
 	}
 }
 
+func TestPrimitiveSchema_HandlesProps(t *testing.T) {
+	schm := `
+{
+   "type": "string",
+   "foo": "bar",
+   "baz": 1
+}
+`
+
+	s, err := avro.Parse(schm)
+
+	assert.NoError(t, err)
+	assert.Equal(t, avro.String, s.Type())
+	assert.Equal(t, "bar", s.(*avro.PrimitiveSchema).Prop("foo"))
+	assert.Equal(t, float64(1), s.(*avro.PrimitiveSchema).Prop("baz"))
+}
+
 func TestRecordSchema(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This parses properties defined in primitive schemas and exposes them on `PrimitiveSchema`.

Fixes #158 