### PR TITLE
patch: added GetSchemaInfo to registry client

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -45,6 +45,9 @@ type Registry interface {
 	// GetLatestSchema gets the latest schema for a subject.
 	GetLatestSchema(ctx context.Context, subject string) (avro.Schema, error)
 
+	// GetSchemaInfo gets the schema and schema metadata for a subject and version
+	GetSchemaInfo(ctx context.Context, subject string, version int) (SchemaInfo, error)
+
 	// GetLatestSchemaInfo gets the latest schema and schema metadata for a subject.
 	GetLatestSchemaInfo(ctx context.Context, subject string) (SchemaInfo, error)
 
@@ -230,6 +233,18 @@ func (c *Client) GetLatestSchema(ctx context.Context, subject string) (avro.Sche
 	}
 
 	return avro.Parse(payload.Schema)
+}
+
+// GetSchemaInfo gets the schema and schema metadata for a subject and version.
+func (c *Client) GetSchemaInfo(ctx context.Context, subject string, version int) (SchemaInfo, error) {
+	var payload schemaInfoPayload
+	p := path.Join("subjects", subject, "versions", strconv.Itoa(version))
+	err := c.request(ctx, http.MethodGet, p, nil, &payload)
+	if err != nil {
+		return SchemaInfo{}, err
+	}
+
+	return payload.Parse()
 }
 
 // GetLatestSchemaInfo gets the latest schema and schema metadata for a subject.

--- a/registry/client.go
+++ b/registry/client.go
@@ -45,7 +45,7 @@ type Registry interface {
 	// GetLatestSchema gets the latest schema for a subject.
 	GetLatestSchema(ctx context.Context, subject string) (avro.Schema, error)
 
-	// GetSchemaInfo gets the schema and schema metadata for a subject and version
+	// GetSchemaInfo gets the schema and schema metadata for a subject and version.
 	GetSchemaInfo(ctx context.Context, subject string, version int) (SchemaInfo, error)
 
 	// GetLatestSchemaInfo gets the latest schema and schema metadata for a subject.


### PR DESCRIPTION
## Overview

Clients desiring to marshal data to [wire format](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format) need access to the id of the schema.

Often times clients will fix their code to a specific version while schema maintainers will continue to develop new versions.

This PR exposes the `GetSchemaInfo` method on the registry client that takes a `subject` and `version` to allow users to subsequently encode to wire format.



