### PR TITLE
feat: add read function for ocf decoder

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -43,6 +43,17 @@ func (d *Decoder) Decode(obj interface{}) error {
 	return d.r.Error
 }
 
+// Read reads the next Avro encoded value from its input and returns it as byte array.
+func (d *Decoder) Read() ([]byte, error) {
+	if d.r.head == d.r.tail && d.r.reader != nil {
+		if !d.r.loadMore() {
+			return nil, io.EOF
+		}
+	}
+
+	return d.r.buf, d.r.Error
+}
+
 // Unmarshal parses the Avro encoded data and stores the result in the value pointed to by v.
 // If v is nil or not a pointer, Unmarshal returns an error.
 func Unmarshal(schema Schema, data []byte, v interface{}) error {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -56,6 +56,41 @@ func TestDecoder_DecodeNonPtr(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDecoder_Read(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x01}
+	schema := "boolean"
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	assert.NoError(t, err)
+
+	byteArr, err := dec.Read()
+
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(byteArr))
+
+	byteArr, err = dec.Read()
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(byteArr))
+
+	byteArr, err = dec.Read()
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(byteArr))
+}
+
+func TestDecoder_ReadEOF(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{}
+	schema := "int"
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	byteArr, err := dec.Read()
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(byteArr))
+}
+
 func TestDecoder_DecodeNilPtr(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -119,6 +119,17 @@ func (d *Decoder) Decode(v interface{}) error {
 	return d.decoder.Decode(v)
 }
 
+// Read reads the next Avro encoded value from its input and returns it as byte array.
+func (d *Decoder) Read() ([]byte, error) {
+	if d.count <= 0 {
+		return nil, errors.New("decoder: no data found, call HasNext first")
+	}
+
+	d.count--
+
+	return d.decoder.Read()
+}
+
 // Error returns the last reader error.
 func (d *Decoder) Error() error {
 	if errors.Is(d.reader.Error, io.EOF) {

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -145,6 +145,52 @@ func TestDecoder(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+func TestDecoderRead(t *testing.T) {
+	f, err := os.Open("../testdata/full.avro")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	dec, err := ocf.NewDecoder(f)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	var count int
+	for dec.HasNext() {
+		count++
+
+		byteArr, err := dec.Read()
+
+		require.NoError(t, err)
+		assert.NotEqual(t, 0, len(byteArr))
+	}
+
+	require.NoError(t, dec.Error())
+	assert.Equal(t, 1, count)
+}
+
+func TestDecoderRead_Error(t *testing.T) {
+	f, err := os.Open("../testdata/full.avro")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	dec, err := ocf.NewDecoder(f)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	_, err = dec.Read()
+	assert.Error(t, err)
+}
+
 func TestDecoderDeflate(t *testing.T) {
 	unionStr := "union value"
 	want := FullRecord{


### PR DESCRIPTION
This allows the user to read the byte array value of the block, without decoding it. User can use this value for ocf write function.

Fixes #186 