### PR TITLE
feat: Added new config option to support partial union type resolution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ type name, or scheam full name in the case of a named schema (enum, fixed or rec
 with one of the types being `null` (ie. `["null", "string"]` or `["string", "null"]`), in this case 
 a `*T` is allowed, with `T` matching the conversion table above.
 * **interface{}:** An `interface` can be provided and the type or name resolved. Primitive types
-are pre-registered, but named types, maps and slices will need to be registered with the `Register` function. In the 
-case of arrays and maps the enclosed schema type or name is postfix to the type
-with a `:` separator, e.g `"map:string"`. If any type cannot be resolved the map type above is used unless
-`Config.UnionResolutionError` is set to `true` in which case an error is returned.
+are pre-registered, but named types, maps and slices will need to be registered with the `Register` function. 
+In the case of arrays and maps the enclosed schema type or name is postfix to the type with a `:` separator, 
+e.g `"map:string"`. Behavior when a type cannot be resolved will depend on your chosen configuation options:
+	* !Config.UnionResolutionError && !Config.PartialUnionTypeResolution: the map type above is used
+	* Config.UnionResolutionError && !Config.PartialUnionTypeResolution: an error is returned
+	* !Config.UnionResolutionError && Config.PartialUnionTypeResolution: any registered type will get resolved while any unregistered type will fallback to the map type above.
+	* Config.UnionResolutionError && !Config.PartialUnionTypeResolution: any registered type will get resolved while any unregistered type will return an error.
 
 ##### TextMarshaler and TextUnmarshaler
 

--- a/codec_union.go
+++ b/codec_union.go
@@ -236,6 +236,12 @@ func decoderOfResolvedUnion(cfg *frozenConfig, schema Schema) ValDecoder {
 			continue
 		}
 
+		if cfg.config.PartialUnionTypeResolution {
+			decoders[i] = nil
+			types[i] = nil
+			continue
+		}
+
 		decoders = []ValDecoder{}
 		types = []reflect2.Type{}
 		break
@@ -269,7 +275,7 @@ func (d *unionResolvedDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 		return
 	}
 
-	if i >= len(d.decoders) {
+	if i >= len(d.decoders) || d.decoders[i] == nil {
 		if d.cfg.config.UnionResolutionError {
 			r.ReportError("decode union type", "unknown union type")
 			return

--- a/config.go
+++ b/config.go
@@ -24,6 +24,14 @@ type Config struct {
 	// UnionResolutionError determines if an error will be returned
 	// when a type cannot be resolved while decoding a union.
 	UnionResolutionError bool
+
+	// PartialUnionTypeResolution dictates if the union type resolution
+	// should be attempted even when not all union types are registered.
+	// When enabled, the underlying type will get resolved if it is registered
+	// even if other types of the union are not. If resolution fails, logic
+	// falls back to default union resolution behavior based on the value of
+	// UnionResolutionError.
+	PartialUnionTypeResolution bool
 }
 
 // Freeze makes the configuration immutable.

--- a/decoder_union_test.go
+++ b/decoder_union_test.go
@@ -465,6 +465,79 @@ func TestDecoder_UnionInterfaceUnresolvableType(t *testing.T) {
 	assert.Equal(t, "foo", m["test"].(map[string]interface{})["b"])
 }
 
+func TestDecoder_UnionInterfaceDualRecords(t *testing.T) {
+	defer ConfigTeardown()
+
+	avro.Register("test", &TestRecord{})
+	avro.Register("otherTest", &TestRecord{})
+
+	data := []byte{0x02, 0x36, 0x06, 0x66, 0x6F, 0x6F}
+	schema := `[
+		"int", 
+		{"type": "record", "name": "test", "fields" : [{"name": "a", "type": "long"}, {"name": "b", "type": "string"}]},
+		{"type": "record", "name": "otherTest", "fields" : [{"name": "a", "type": "long"}, {"name": "b", "type": "string"}]}
+	]`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got interface{}
+	err := dec.Decode(&got)
+
+	require.NoError(t, err)
+	assert.IsType(t, &TestRecord{}, got)
+	rec := got.(*TestRecord)
+	assert.Equal(t, int64(27), rec.A)
+	assert.Equal(t, "foo", rec.B)
+}
+
+func TestDecoder_UnionInterfaceDualRecordsUnresolvableType(t *testing.T) {
+	defer ConfigTeardown()
+
+	avro.Register("test", &TestRecord{})
+
+	data := []byte{0x02, 0x36, 0x06, 0x66, 0x6F, 0x6F}
+	schema := `[
+		"int", 
+		{"type": "record", "name": "test", "fields" : [{"name": "a", "type": "long"}, {"name": "b", "type": "string"}]},
+		{"type": "record", "name": "otherTest", "fields" : [{"name": "a", "type": "long"}, {"name": "b", "type": "string"}]}
+	]`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got interface{}
+	err := dec.Decode(&got)
+
+	require.NoError(t, err)
+	assert.IsType(t, map[string]interface{}{}, got)
+	m := got.(map[string]interface{})
+	assert.IsType(t, map[string]interface{}{}, m["test"])
+	assert.Equal(t, int64(27), m["test"].(map[string]interface{})["a"])
+	assert.Equal(t, "foo", m["test"].(map[string]interface{})["b"])
+}
+
+func TestDecoder_UnionInterfaceDualRecordsPartialResolution(t *testing.T) {
+	defer ConfigTeardown()
+
+	avro.DefaultConfig = avro.Config{PartialUnionTypeResolution: true}.Freeze()
+
+	avro.Register("test", &TestRecord{})
+
+	data := []byte{0x02, 0x36, 0x06, 0x66, 0x6F, 0x6F}
+	schema := `[
+		"int", 
+		{"type": "record", "name": "test", "fields" : [{"name": "a", "type": "long"}, {"name": "b", "type": "string"}]},
+		{"type": "record", "name": "otherTest", "fields" : [{"name": "a", "type": "long"}, {"name": "b", "type": "string"}]}
+	]`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got interface{}
+	err := dec.Decode(&got)
+
+	require.NoError(t, err)
+	assert.IsType(t, &TestRecord{}, got)
+	rec := got.(*TestRecord)
+	assert.Equal(t, int64(27), rec.A)
+	assert.Equal(t, "foo", rec.B)
+}
+
 func TestDecoder_UnionInterfaceWithTime(t *testing.T) {
 	defer ConfigTeardown()
 


### PR DESCRIPTION
When enabled, the union decoder will attempt to resolve the encountered union type. If no decoder is available, the logic falls back to the existing configuration option (error out or return a map).

Fixes #191 