### PR TITLE
fix: Flush() should flush underlying avro writer (#196)

### DIFF
--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -233,6 +233,10 @@ func NewEncoder(s string, w io.Writer, opts ...EncoderFunc) (*Encoder, error) {
 	}
 	_, _ = rand.Read(header.Sync[:])
 	writer.WriteVal(HeaderSchema, header)
+	err = writer.Flush()
+	if err != nil {
+		return nil, err
+	}
 
 	codec, err := resolveCodec(cfg.CodecName, cfg.CodecCompression)
 	if err != nil {


### PR DESCRIPTION
This is useful when one wants a file with *just* the Avro header, for instance in order to convey the schema and no records.

Fixes #196 