### PR TITLE
fix: add addition error context

### DIFF
--- a/codec_array.go
+++ b/codec_array.go
@@ -56,6 +56,10 @@ func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 		for i := start; i < size; i++ {
 			elemPtr := sliceType.UnsafeGetIndex(ptr, i)
 			d.decoder.Decode(elemPtr, r)
+			if r.Error != nil && !errors.Is(r.Error, io.EOF) {
+				r.Error = fmt.Errorf("%s: %w", d.typ.String(), r.Error)
+				return
+			}
 		}
 	}
 
@@ -92,6 +96,10 @@ func (e *arrayEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 			for j := i; j < i+blockLength && j < length; j++ {
 				elemPtr := e.typ.UnsafeGetIndex(ptr, j)
 				e.encoder.Encode(elemPtr, w)
+				if w.Error != nil && !errors.Is(w.Error, io.EOF) {
+					w.Error = fmt.Errorf("%s: %w", e.typ.String(), w.Error)
+					return count
+				}
 				count++
 			}
 

--- a/codec_record.go
+++ b/codec_record.go
@@ -127,8 +127,8 @@ func (d *structDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 		if r.Error != nil && !errors.Is(r.Error, io.EOF) {
 			for _, f := range field.field {
 				r.Error = fmt.Errorf("%s: %w", f.Name(), r.Error)
+				return
 			}
-			return
 		}
 	}
 }
@@ -223,6 +223,7 @@ func (e *structEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 		if w.Error != nil && !errors.Is(w.Error, io.EOF) {
 			for _, f := range field.field {
 				w.Error = fmt.Errorf("%s: %w", f.Name(), w.Error)
+				return
 			}
 		}
 	}
@@ -347,6 +348,11 @@ func (e *recordMapEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 		}
 
 		field.encoder.Encode(valPtr, w)
+
+		if w.Error != nil && !errors.Is(w.Error, io.EOF) {
+			w.Error = fmt.Errorf("%s: %w", field.name, w.Error)
+			return
+		}
 	}
 }
 

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -64,3 +64,17 @@ func TestDecoder_ArraySliceError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestDecoder_ArraySliceItemError(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x04, 0xE2, 0xA2, 0xF3, 0xAD, 0xAD, 0xAD, 0xE2, 0xA2, 0xF3, 0xAD, 0xAD}
+	schema := `{"type":"array", "items": "int"}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got []int
+	err = dec.Decode(&got)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This adds additional context to errors where it was missed. This was pointed out by @nascimento and the original work was done in #177 which seems to have stalled. To improve error handling this should be included in the library though.