### PR TITLE
feat: support text marshaler on enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ e.g `"map:string"`. Behavior when a type cannot be resolved will depend on your 
 
 The interfaces `TextMarshaler` and `TextUnmarshaler` are supported for a `string` schema type. The object will
 be tested first for implementation of these interfaces, in the case of a `string` schema, before trying regular
-encoding and decoding. 
+encoding and decoding.
+
+Enums may also implement `TextMarshaler` and `TextUnmarshaler`, and must resolve to valid symbols in the given enum schema.
 
 ### Recursive Structs
 

--- a/codec_enum.go
+++ b/codec_enum.go
@@ -1,6 +1,8 @@
 package avro
 
 import (
+	"encoding"
+	"errors"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -9,16 +11,22 @@ import (
 )
 
 func createDecoderOfEnum(schema Schema, typ reflect2.Type) ValDecoder {
-	if typ.Kind() == reflect.String {
+	switch {
+	case typ.Kind() == reflect.String:
 		return &enumCodec{symbols: schema.(*EnumSchema).Symbols()}
+	case typ.Implements(textUnmarshalerType):
+		return &enumTextMarshalerCodec{typ: typ, symbols: schema.(*EnumSchema).Symbols()}
 	}
 
 	return &errorDecoder{err: fmt.Errorf("avro: %s is unsupported for Avro %s", typ.String(), schema.Type())}
 }
 
 func createEncoderOfEnum(schema Schema, typ reflect2.Type) ValEncoder {
-	if typ.Kind() == reflect.String {
+	switch {
+	case typ.Kind() == reflect.String:
 		return &enumCodec{symbols: schema.(*EnumSchema).Symbols()}
+	case typ.Implements(textMarshalerType):
+		return &enumTextMarshalerCodec{typ: typ, symbols: schema.(*EnumSchema).Symbols()}
 	}
 
 	return &errorEncoder{err: fmt.Errorf("avro: %s is unsupported for Avro %s", typ.String(), schema.Type())}
@@ -32,7 +40,7 @@ func (c *enumCodec) Decode(ptr unsafe.Pointer, r *Reader) {
 	i := int(r.ReadInt())
 
 	if i < 0 || i >= len(c.symbols) {
-		r.ReportError("decode unknown enum symbol", "unknown enum symbol")
+		r.ReportError("decode enum symbol", "unknown enum symbol")
 		return
 	}
 
@@ -41,6 +49,58 @@ func (c *enumCodec) Decode(ptr unsafe.Pointer, r *Reader) {
 
 func (c *enumCodec) Encode(ptr unsafe.Pointer, w *Writer) {
 	str := *((*string)(ptr))
+	for i, sym := range c.symbols {
+		if str != sym {
+			continue
+		}
+
+		w.WriteInt(int32(i))
+		return
+	}
+
+	w.Error = fmt.Errorf("avro: unknown enum symbol: %s", str)
+}
+
+type enumTextMarshalerCodec struct {
+	typ     reflect2.Type
+	symbols []string
+}
+
+func (c *enumTextMarshalerCodec) Decode(ptr unsafe.Pointer, r *Reader) {
+	i := int(r.ReadInt())
+
+	if i < 0 || i >= len(c.symbols) {
+		r.ReportError("decode enum symbol", "unknown enum symbol")
+		return
+	}
+
+	obj := c.typ.UnsafeIndirect(ptr)
+	if reflect2.IsNil(obj) {
+		ptrType := c.typ.(*reflect2.UnsafePtrType)
+		newPtr := ptrType.Elem().UnsafeNew()
+		*((*unsafe.Pointer)(ptr)) = newPtr
+		obj = c.typ.UnsafeIndirect(ptr)
+	}
+	unmarshaler := (obj).(encoding.TextUnmarshaler)
+	if err := unmarshaler.UnmarshalText([]byte(c.symbols[i])); err != nil {
+		r.ReportError("decode enum text unmarshaler", err.Error())
+	}
+}
+
+func (c *enumTextMarshalerCodec) Encode(ptr unsafe.Pointer, w *Writer) {
+	obj := c.typ.UnsafeIndirect(ptr)
+	if c.typ.IsNullable() && reflect2.IsNil(obj) {
+		w.Error = errors.New("encoding nil enum text marshaler")
+		return
+	}
+	marshaler := (obj).(encoding.TextMarshaler)
+	b, err := marshaler.MarshalText()
+	if err != nil {
+		w.Error = err
+		return
+	}
+
+	str := string(b)
 	for i, sym := range c.symbols {
 		if str != sym {
 			continue

--- a/decoder_enum_test.go
+++ b/decoder_enum_test.go
@@ -2,6 +2,7 @@ package avro_test
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/hamba/avro/v2"
@@ -17,8 +18,8 @@ func TestDecoder_EnumInvalidType(t *testing.T) {
 	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
 	require.NoError(t, err)
 
-	var str int
-	err = dec.Decode(&str)
+	var got int
+	err = dec.Decode(&got)
 
 	assert.Error(t, err)
 }
@@ -62,4 +63,75 @@ func TestDecoder_EnumError(t *testing.T) {
 	err = dec.Decode(&got)
 
 	assert.Error(t, err)
+}
+
+func TestDecoder_EnumTextUnmarshaler(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x02}
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got *testEnumTextUnmarshaler
+	err := dec.Decode(&got)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testEnumTextUnmarshaler(1), *got)
+}
+
+func TestDecoder_EnumTextUnmarshalerInvalidSymbol(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x04}
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got *testEnumTextUnmarshaler
+	err := dec.Decode(&got)
+
+	assert.Error(t, err)
+}
+
+func TestDecoder_EnumTextUnmarshalerEnumError(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0xE2, 0xA2, 0xF3, 0xAD, 0xAD, 0xAD}
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got *testEnumTextUnmarshaler
+	err = dec.Decode(&got)
+
+	assert.Error(t, err)
+}
+
+func TestDecoder_EnumTextUnmarshalerError(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x04}
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar", "baz"]}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got *testEnumTextUnmarshaler
+	err = dec.Decode(&got)
+
+	assert.Error(t, err)
+}
+
+type testEnumTextUnmarshaler int
+
+func (m *testEnumTextUnmarshaler) UnmarshalText(data []byte) error {
+	switch string(data) {
+	case "foo":
+		*m = 0
+		return nil
+	case "bar":
+		*m = 1
+		return nil
+	default:
+		return errors.New("unknown symbol")
+	}
 }

--- a/encoder_enum_test.go
+++ b/encoder_enum_test.go
@@ -2,6 +2,7 @@ package avro_test
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/hamba/avro/v2"
@@ -47,4 +48,92 @@ func TestEncoder_EnumInvalidSymbol(t *testing.T) {
 	err = enc.Encode("baz")
 
 	assert.Error(t, err)
+}
+
+func TestEncoder_EnumTextMarshaler(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	m := testEnumTextMarshaler(1)
+	err = enc.Encode(m)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02}, buf.Bytes())
+}
+
+func TestEncoder_EnumTextMarshalerPtr(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	m := testEnumTextMarshaler(1)
+	ptr := &m
+	err = enc.Encode(ptr)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02}, buf.Bytes())
+}
+
+func TestEncoder_EnumTextMarshalerInvalidSymbol(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	m := testEnumTextMarshaler(2)
+	err = enc.Encode(m)
+
+	assert.Error(t, err)
+}
+
+func TestEncoder_EnumTextMarshalerNil(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var m *testEnumTextMarshaler
+	err = enc.Encode(m)
+
+	assert.Error(t, err)
+}
+
+func TestEncoder_EnumTextMarshalerError(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"enum", "name": "test", "symbols": ["foo", "bar"]}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	m := testEnumTextMarshaler(3)
+	err = enc.Encode(m)
+
+	assert.Error(t, err)
+}
+
+type testEnumTextMarshaler int
+
+func (m testEnumTextMarshaler) MarshalText() ([]byte, error) {
+	switch m {
+	case 0:
+		return []byte("foo"), nil
+	case 1:
+		return []byte("bar"), nil
+	case 2:
+		return []byte("baz"), nil
+	default:
+		return nil, errors.New("unknown symbol")
+	}
 }


### PR DESCRIPTION
This adds support for the `TextMarshaler` and `TextUnmarshaler` interfaces on enums. The implementations of the interfaces must resolve to valid symbols in the schema, otherwise an error will with returned.

Fixes #205 