### PR TITLE
Improved union type resolution error

### DIFF
--- a/codec_union.go
+++ b/codec_union.go
@@ -27,7 +27,11 @@ func createDecoderOfUnion(cfg *frozenConfig, schema Schema, typ reflect2.Type) V
 
 	case reflect.Interface:
 		if _, ok := typ.(*reflect2.UnsafeIFaceType); !ok {
-			return decoderOfResolvedUnion(cfg, schema)
+			if dec, err := decoderOfResolvedUnion(cfg, schema); err != nil {
+				return &errorDecoder{err: fmt.Errorf("avro: problem resolving decoder for Avro %s: %w", schema.Type(), err)}
+			} else {
+				return dec
+			}
 		}
 	}
 
@@ -222,18 +226,24 @@ func (e *unionPtrEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 	e.encoder.Encode(*((*unsafe.Pointer)(ptr)), w)
 }
 
-func decoderOfResolvedUnion(cfg *frozenConfig, schema Schema) ValDecoder {
+func decoderOfResolvedUnion(cfg *frozenConfig, schema Schema) (ValDecoder, error) {
 	union := schema.(*UnionSchema)
 
 	types := make([]reflect2.Type, len(union.Types()))
 	decoders := make([]ValDecoder, len(union.Types()))
 	for i, schema := range union.Types() {
 		name := unionResolutionName(schema)
-		if typ, err := cfg.resolver.Type(name); err == nil {
+
+		typ, err := cfg.resolver.Type(name)
+		if err == nil {
 			decoder := decoderOfType(cfg, schema, typ)
 			decoders[i] = decoder
 			types[i] = typ
 			continue
+		}
+
+		if cfg.config.UnionResolutionError {
+			return nil, err
 		}
 
 		if cfg.config.PartialUnionTypeResolution {
@@ -252,7 +262,7 @@ func decoderOfResolvedUnion(cfg *frozenConfig, schema Schema) ValDecoder {
 		schema:   union,
 		types:    types,
 		decoders: decoders,
-	}
+	}, nil
 }
 
 type unionResolvedDecoder struct {

--- a/decoder_union_test.go
+++ b/decoder_union_test.go
@@ -633,7 +633,7 @@ func TestDecoder_UnionInterfaceUnresolvableTypeWithError(t *testing.T) {
 	var got interface{}
 	err := dec.Decode(&got)
 
-	assert.Error(t, err)
+	assert.EqualError(t, err, "avro: problem resolving decoder for Avro union: avro: unable to resolve type with name test")
 }
 
 func TestDecoder_UnionInterfaceInvalidSchema(t *testing.T) {


### PR DESCRIPTION
- updated the union type resolution error to give the union type from the schema that couldn't be resolved. The message when from `"avro: decode union type: unknown union type"` to `"avro: problem resolving decoder for Avro union: avro: unable to resolve type with name test"`. The reason I did this was because I was having a difficult time interpreting the error and had to step through the debugger to see what the problem is.