### PR TITLE
feat: Added configuration option to disable encoder/decoder caching layer if needed

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	// falls back to default union resolution behavior based on the value of
 	// UnionResolutionError.
 	PartialUnionTypeResolution bool
+
+	// Disable caching layer for encoders and decoders, forcing them to get rebuilt on every
+	// call to Marshal() and Unmarshal()
+	DisableCaching bool
 }
 
 // Freeze makes the configuration immutable.
@@ -187,11 +191,17 @@ type cacheKey struct {
 }
 
 func (c *frozenConfig) addDecoderToCache(fingerprint [32]byte, rtype uintptr, dec ValDecoder) {
+	if c.config.DisableCaching {
+		return
+	}
 	key := cacheKey{fingerprint: fingerprint, rtype: rtype}
 	c.decoderCache.Store(key, dec)
 }
 
 func (c *frozenConfig) getDecoderFromCache(fingerprint [32]byte, rtype uintptr) ValDecoder {
+	if c.config.DisableCaching {
+		return nil
+	}
 	key := cacheKey{fingerprint: fingerprint, rtype: rtype}
 	if dec, ok := c.decoderCache.Load(key); ok {
 		return dec.(ValDecoder)
@@ -201,11 +211,17 @@ func (c *frozenConfig) getDecoderFromCache(fingerprint [32]byte, rtype uintptr) 
 }
 
 func (c *frozenConfig) addEncoderToCache(fingerprint [32]byte, rtype uintptr, enc ValEncoder) {
+	if c.config.DisableCaching {
+		return
+	}
 	key := cacheKey{fingerprint: fingerprint, rtype: rtype}
 	c.encoderCache.Store(key, enc)
 }
 
 func (c *frozenConfig) getEncoderFromCache(fingerprint [32]byte, rtype uintptr) ValEncoder {
+	if c.config.DisableCaching {
+		return nil
+	}
 	key := cacheKey{fingerprint: fingerprint, rtype: rtype}
 	if enc, ok := c.encoderCache.Load(key); ok {
 		return enc.(ValEncoder)

--- a/config_internal_test.go
+++ b/config_internal_test.go
@@ -44,6 +44,33 @@ func TestConfig_ReusesDecoders(t *testing.T) {
 	assert.Same(t, dec1, dec2)
 }
 
+func TestConfig_DisableCache_DoesNotReuseDecoders(t *testing.T) {
+	type testObj struct {
+		A int64 `avro:"a"`
+	}
+
+	api := Config{
+		TagKey:         "test",
+		BlockLength:    2,
+		DisableCaching: true,
+	}.Freeze()
+	cfg := api.(*frozenConfig)
+
+	schema := MustParse(`{
+	"type": "record",
+	"name": "test",
+	"fields" : [
+		{"name": "a", "type": "long"}
+	]
+}`)
+	typ := reflect2.TypeOfPtr(&testObj{})
+
+	dec1 := cfg.DecoderOf(schema, typ)
+	dec2 := cfg.DecoderOf(schema, typ)
+
+	assert.NotSame(t, dec1, dec2)
+}
+
 func TestConfig_ReusesEncoders(t *testing.T) {
 	type testObj struct {
 		A int64 `avro:"a"`
@@ -68,4 +95,31 @@ func TestConfig_ReusesEncoders(t *testing.T) {
 	enc2 := cfg.EncoderOf(schema, typ)
 
 	assert.Same(t, enc1, enc2)
+}
+
+func TestConfig_DisableCache_DoesNotReuseEncoders(t *testing.T) {
+	type testObj struct {
+		A int64 `avro:"a"`
+	}
+
+	api := Config{
+		TagKey:         "test",
+		BlockLength:    2,
+		DisableCaching: true,
+	}.Freeze()
+	cfg := api.(*frozenConfig)
+
+	schema := MustParse(`{
+	"type": "record",
+	"name": "test",
+	"fields" : [
+		{"name": "a", "type": "long"}
+	]
+}`)
+	typ := reflect2.TypeOfPtr(testObj{})
+
+	enc1 := cfg.EncoderOf(schema, typ)
+	enc2 := cfg.EncoderOf(schema, typ)
+
+	assert.NotSame(t, enc1, enc2)
 }


### PR DESCRIPTION
This is suggested as disabling cache can sometimes be desired based on the upstream implementation

Fixes #216 