### PR TITLE
Add references to `Registry.IsRegistered()`

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -58,7 +58,7 @@ type Registry interface {
 	IsRegistered(ctx context.Context, subject, schema string) (int, avro.Schema, error)
 
 	// IsRegisteredWithRefs determines if the schema is registered, with optional referenced schemas.
-	IsRegisteredWithRefs(ctx context.Context, subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
+	IsRegisteredWithRefs(ctx context.Context, subject, schema string, refs ...SchemaReference) (int, avro.Schema, error)
 }
 
 type schemaPayload struct {

--- a/registry/client.go
+++ b/registry/client.go
@@ -55,7 +55,7 @@ type Registry interface {
 	CreateSchema(ctx context.Context, subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
 
 	// IsRegistered determines of the schema is registered.
-	IsRegistered(ctx context.Context, subject, schema string) (int, avro.Schema, error)
+	IsRegistered(ctx context.Context, subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
 }
 
 type schemaPayload struct {
@@ -277,10 +277,15 @@ func (c *Client) CreateSchema(
 }
 
 // IsRegistered determines of the schema is registered.
-func (c *Client) IsRegistered(ctx context.Context, subject, schema string) (int, avro.Schema, error) {
+func (c *Client) IsRegistered(
+	ctx context.Context,
+	subject, schema string,
+	references ...SchemaReference,
+) (int, avro.Schema, error) {
 	var payload idPayload
 	p := path.Join("subjects", subject)
-	err := c.request(ctx, http.MethodPost, p, schemaPayload{Schema: schema}, &payload)
+	inPayload := schemaPayload{Schema: schema, References: references}
+	err := c.request(ctx, http.MethodPost, p, inPayload, &payload)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/registry/client.go
+++ b/registry/client.go
@@ -54,8 +54,11 @@ type Registry interface {
 	// CreateSchema creates a schema in the registry, returning the schema id.
 	CreateSchema(ctx context.Context, subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
 
-	// IsRegistered determines of the schema is registered.
-	IsRegistered(ctx context.Context, subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
+	// IsRegistered determines if the schema is registered.
+	IsRegistered(ctx context.Context, subject, schema string) (int, avro.Schema, error)
+
+	// IsRegisteredWithRefs determines if the schema is registered, with optional referenced schemas.
+	IsRegisteredWithRefs(ctx context.Context, subject, schema string, references ...SchemaReference) (int, avro.Schema, error)
 }
 
 type schemaPayload struct {
@@ -276,8 +279,13 @@ func (c *Client) CreateSchema(
 	return payload.ID, sch, err
 }
 
-// IsRegistered determines of the schema is registered.
-func (c *Client) IsRegistered(
+// IsRegistered determines if the schema is registered.
+func (c *Client) IsRegistered(ctx context.Context, subject, schema string) (int, avro.Schema, error) {
+	return c.IsRegisteredWithRefs(ctx, subject, schema)
+}
+
+// IsRegisteredWithRefs determines if the schema is registered, with optional referenced schemas.
+func (c *Client) IsRegisteredWithRefs(
 	ctx context.Context,
 	subject, schema string,
 	references ...SchemaReference,


### PR DESCRIPTION
This PR adds the `references` parameter to the Registry.IsRegistered(), as per the official [Schema Registry API documentation](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--subjects-(string-%20subject)):

> POST /subjects/(string: subject)
> 
> Request JSON Object:
>  	
> - schema – The schema string
> - schemaType – Defines the schema format: AVRO (default), PROTOBUF, JSONSCHEMA (Optional)
> - references – Specifies the names of referenced schemas (Optional). To learn more, see [Schema References](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#referenced-schemas).
> 

Note that this will be a breaking change to the `Registry` interface, as the `IsRegistered()` method signature has changed.

Fixes #221 