### PR TITLE
Registry compatibility level

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -365,7 +365,7 @@ const (
 )
 
 /*
-this function returns whether or not a compatibility level
+ValidCompatibilityLevel returns whether or not a compatibility level
 is valid according to the ones described in:
 https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
 .

--- a/registry/client.go
+++ b/registry/client.go
@@ -370,7 +370,7 @@ is valid according to the ones described in:
 https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
 .
 */
-func validCompatibilityLevel(compatibilityLevel string) bool {
+func ValidCompatibilityLevel(compatibilityLevel string) bool {
 	switch compatibilityLevel {
 	case BackwardCL:
 		return true
@@ -410,7 +410,7 @@ func (c *Client) PutCompatibilityLevelGlobal(
 	ctx context.Context,
 	compatibilityLevel string,
 ) (string, error) {
-	if !validCompatibilityLevel(compatibilityLevel) {
+	if !ValidCompatibilityLevel(compatibilityLevel) {
 		return "", errByInvalidCL(compatibilityLevel)
 	}
 	var payload compatibilityPayload
@@ -428,7 +428,7 @@ func (c *Client) PutCompatibilityLevel(
 	ctx context.Context,
 	subject, compatibilityLevel string,
 ) (string, error) {
-	if !validCompatibilityLevel(compatibilityLevel) {
+	if !ValidCompatibilityLevel(compatibilityLevel) {
 		return "", errByInvalidCL(compatibilityLevel)
 	}
 	var payload compatibilityPayload

--- a/registry/client.go
+++ b/registry/client.go
@@ -364,18 +364,17 @@ const (
 	NoneCL               string = "NONE"
 )
 
-/*
-ValidateCompatibilityLevel returns whether or not a compatibility level
-is valid according to the ones described in:
-https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
-.
-*/
+// ValidateCompatibilityLevel returns whether or not a compatibility level
+// is valid according to the ones described in:
+// https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
+// .
+
 func ValidateCompatibilityLevel(lvl string) error {
 	switch lvl {
 	case BackwardCL, BackwardTransitiveCL, ForwardCL, ForwardTransitiveCL, FullCL, FullTransitiveCL, NoneCL:
 		return nil
 	default:
-		return errByInvalidCL(lvl)
+		return fmt.Errorf("invalid compatibility level %s", lvl)
 	}
 }
 
@@ -384,23 +383,14 @@ type compatibilityPayload struct {
 	Compatibility string `json:"compatibility"`
 }
 
-/*
-errByInvalidCL returns error for and invalid compatibility level, i.e. a compatibility
-level not present in:
-https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility .
-*/
-func errByInvalidCL(lvl string) error {
-	return fmt.Errorf("invalid compatibility level %s", lvl)
-}
-
-// PutCompatibilityLevelGlobal sets the global compatibility level of the registry.
-func (c *Client) PutCompatibilityLevelGlobal(
+// SetGlobalCompatibilityLevel sets the global compatibility level of the registry.
+func (c *Client) SetGlobalCompatibilityLevel(
 	ctx context.Context,
 	lvl string,
 ) (string, error) {
 	err := ValidateCompatibilityLevel(lvl)
 	if err != nil {
-		return "", errByInvalidCL(lvl)
+		return "", err
 	}
 	var payload compatibilityPayload
 	inPayload := compatibilityPayload{Compatibility: lvl}
@@ -412,14 +402,14 @@ func (c *Client) PutCompatibilityLevelGlobal(
 	return payload.Compatibility, nil
 }
 
-// PutCompatibilityLevel sets the compatibility level of a subject.
-func (c *Client) PutCompatibilityLevel(
+// SetCompatibilityLevel sets the compatibility level of a subject.
+func (c *Client) SetCompatibilityLevel(
 	ctx context.Context,
 	subject, lvl string,
 ) (string, error) {
 	err := ValidateCompatibilityLevel(lvl)
 	if err != nil {
-		return "", errByInvalidCL(lvl)
+		return "", err
 	}
 	var payload compatibilityPayload
 	inPayload := compatibilityPayload{Compatibility: lvl}

--- a/registry/client.go
+++ b/registry/client.go
@@ -352,3 +352,33 @@ func (e Error) Error() string {
 
 	return "registry error: " + strconv.Itoa(e.StatusCode)
 }
+
+// code for compatibility levels
+
+const (
+	BackwardCL           string = "BACKWARD"
+	BackwardTransitiveCL string = "BACKWARD_TRANSITIVE"
+	ForwardCL            string = "FORWARD"
+	ForwardTransitiveCL  string = "FORWARD_TRANSITIVE"
+	FullCL               string = "FULL"
+	FullTransitiveCL     string = "FULL_TRANSITIVE"
+	NoneCL               string = "NONE"
+)
+
+type compatibilityPayload struct {
+	Compatibility string `json:"compatibility"`
+}
+
+func (c *Client) PutCompatibilityLevel(
+	ctx context.Context,
+	subject, compatibility_level string,
+) (string, error) {
+	var payload compatibilityPayload
+	inPayload := compatibilityPayload{Compatibility: compatibility_level}
+	err := c.request(ctx, http.MethodPut, "config/"+subject, inPayload, &payload)
+	if err != nil {
+		return "", err
+	}
+
+	return payload.Compatibility, nil
+}

--- a/registry/client.go
+++ b/registry/client.go
@@ -415,7 +415,7 @@ func (c *Client) PutCompatibilityLevelGlobal(
 	}
 	var payload compatibilityPayload
 	inPayload := compatibilityPayload{Compatibility: compatibilityLevel}
-	err := c.request(ctx, http.MethodPut, "config/", inPayload, &payload)
+	err := c.request(ctx, http.MethodPut, "config", inPayload, &payload)
 	if err != nil {
 		return "", err
 	}
@@ -446,7 +446,7 @@ func (c *Client) GetCompatibilityLevelGlobal(
 	ctx context.Context,
 ) (string, error) {
 	var payload compatibilityPayload
-	err := c.request(ctx, http.MethodGet, "config/", nil, &payload)
+	err := c.request(ctx, http.MethodGet, "config", nil, &payload)
 	if err != nil {
 		return "", err
 	}

--- a/registry/client.go
+++ b/registry/client.go
@@ -421,8 +421,8 @@ func (c *Client) SetCompatibilityLevel(
 	return payload.Compatibility, nil
 }
 
-// GetCompatibilityLevelGlobal gets the global compatibility level.
-func (c *Client) GetCompatibilityLevelGlobal(
+// GetGlobalCompatibilityLevel gets the global compatibility level.
+func (c *Client) GetGlobalCompatibilityLevel(
 	ctx context.Context,
 ) (string, error) {
 	var payload compatibilityPayload

--- a/registry/client.go
+++ b/registry/client.go
@@ -387,38 +387,38 @@ type compatibilityPayload struct {
 func (c *Client) SetGlobalCompatibilityLevel(
 	ctx context.Context,
 	lvl string,
-) (string, error) {
+) error {
 	err := validateCompatibilityLevel(lvl)
 	if err != nil {
-		return "", err
+		return err
 	}
 	var payload compatibilityPayload
 	inPayload := compatibilityPayload{Compatibility: lvl}
 	err = c.request(ctx, http.MethodPut, "config", inPayload, &payload)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return payload.Compatibility, nil
+	return nil
 }
 
 // SetCompatibilityLevel sets the compatibility level of a subject.
 func (c *Client) SetCompatibilityLevel(
 	ctx context.Context,
 	subject, lvl string,
-) (string, error) {
+) error {
 	err := validateCompatibilityLevel(lvl)
 	if err != nil {
-		return "", err
+		return err
 	}
 	var payload compatibilityPayload
 	inPayload := compatibilityPayload{Compatibility: lvl}
 	err = c.request(ctx, http.MethodPut, "config/"+subject, inPayload, &payload)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return payload.Compatibility, nil
+	return nil
 }
 
 // GetGlobalCompatibilityLevel gets the global compatibility level.

--- a/registry/client.go
+++ b/registry/client.go
@@ -353,7 +353,7 @@ func (e Error) Error() string {
 	return "registry error: " + strconv.Itoa(e.StatusCode)
 }
 
-//compatibility levels
+//compatibility levels.
 const (
 	BackwardCL           string = "BACKWARD"
 	BackwardTransitiveCL string = "BACKWARD_TRANSITIVE"
@@ -368,6 +368,7 @@ const (
 this function returns whether or not a compatibility level
 is valid according to the ones described in:
 https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
+.
 */
 func validCompatibilityLevel(compatibility_level string) bool {
 	switch compatibility_level {
@@ -391,7 +392,7 @@ func validCompatibilityLevel(compatibility_level string) bool {
 }
 
 /*
-response obtained from the schema registry when updating a compatibility level
+response obtained from the schema registry when updating a compatibility level.
 */
 type compatibilityPayload struct {
 	Compatibility string `json:"compatibility"`
@@ -401,13 +402,14 @@ type compatibilityPayload struct {
 function returning error for invalid compatibility level, i.e. a compatibility
 level not present in:
 https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
+.
 */
 func errByInvalidCL(compatibility_level string) error {
 	return fmt.Errorf("invalid compatibility level %s", compatibility_level)
 }
 
 /*
-method used to set the global compatibility level of the registry
+method used to set the global compatibility level of the registry.
 */
 func (c *Client) PutCompatibilityLevelGlobal(
 	ctx context.Context,
@@ -427,7 +429,7 @@ func (c *Client) PutCompatibilityLevelGlobal(
 }
 
 /*
-method used to set the compatibility level of a subject
+method used to set the compatibility level of a subject.
 */
 func (c *Client) PutCompatibilityLevel(
 	ctx context.Context,
@@ -447,7 +449,7 @@ func (c *Client) PutCompatibilityLevel(
 }
 
 /*
-method used to get the global compatibility level
+method used to get the global compatibility level.
 */
 func (c *Client) GetCompatibilityLevelGlobal(
 	ctx context.Context,
@@ -462,7 +464,7 @@ func (c *Client) GetCompatibilityLevelGlobal(
 }
 
 /*
-method used to get the global compatibility level of a subject
+method used to get the global compatibility level of a subject.
 */
 func (c *Client) GetCompatibilityLevel(
 	ctx context.Context,

--- a/registry/client.go
+++ b/registry/client.go
@@ -369,7 +369,7 @@ const (
 // https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
 // .
 
-func ValidateCompatibilityLevel(lvl string) error {
+func validateCompatibilityLevel(lvl string) error {
 	switch lvl {
 	case BackwardCL, BackwardTransitiveCL, ForwardCL, ForwardTransitiveCL, FullCL, FullTransitiveCL, NoneCL:
 		return nil
@@ -388,7 +388,7 @@ func (c *Client) SetGlobalCompatibilityLevel(
 	ctx context.Context,
 	lvl string,
 ) (string, error) {
-	err := ValidateCompatibilityLevel(lvl)
+	err := validateCompatibilityLevel(lvl)
 	if err != nil {
 		return "", err
 	}
@@ -407,7 +407,7 @@ func (c *Client) SetCompatibilityLevel(
 	ctx context.Context,
 	subject, lvl string,
 ) (string, error) {
-	err := ValidateCompatibilityLevel(lvl)
+	err := validateCompatibilityLevel(lvl)
 	if err != nil {
 		return "", err
 	}

--- a/registry/client.go
+++ b/registry/client.go
@@ -353,7 +353,7 @@ func (e Error) Error() string {
 	return "registry error: " + strconv.Itoa(e.StatusCode)
 }
 
-//compatibility levels.
+// Compatibility levels.
 const (
 	BackwardCL           string = "BACKWARD"
 	BackwardTransitiveCL string = "BACKWARD_TRANSITIVE"
@@ -370,8 +370,8 @@ is valid according to the ones described in:
 https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
 .
 */
-func validCompatibilityLevel(compatibility_level string) bool {
-	switch compatibility_level {
+func validCompatibilityLevel(compatibilityLevel string) bool {
+	switch compatibilityLevel {
 	case BackwardCL:
 		return true
 	case BackwardTransitiveCL:
@@ -391,35 +391,30 @@ func validCompatibilityLevel(compatibility_level string) bool {
 	}
 }
 
-/*
-response obtained from the schema registry when updating a compatibility level.
-*/
+// compatibilityPayload is the response body obtained from the schema registry when updating a compatibility level.
 type compatibilityPayload struct {
 	Compatibility string `json:"compatibility"`
 }
 
 /*
-function returning error for invalid compatibility level, i.e. a compatibility
+errByInvalidCL returns error for and invalid compatibility level, i.e. a compatibility
 level not present in:
-https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility
-.
+https://docs.confluent.io/platform/current/schema-registry/develop/api.html#compatibility .
 */
-func errByInvalidCL(compatibility_level string) error {
-	return fmt.Errorf("invalid compatibility level %s", compatibility_level)
+func errByInvalidCL(compatibilityLevel string) error {
+	return fmt.Errorf("invalid compatibility level %s", compatibilityLevel)
 }
 
-/*
-method used to set the global compatibility level of the registry.
-*/
+// PutCompatibilityLevelGlobal sets the global compatibility level of the registry.
 func (c *Client) PutCompatibilityLevelGlobal(
 	ctx context.Context,
-	compatibility_level string,
+	compatibilityLevel string,
 ) (string, error) {
-	if !validCompatibilityLevel(compatibility_level) {
-		return "", errByInvalidCL(compatibility_level)
+	if !validCompatibilityLevel(compatibilityLevel) {
+		return "", errByInvalidCL(compatibilityLevel)
 	}
 	var payload compatibilityPayload
-	inPayload := compatibilityPayload{Compatibility: compatibility_level}
+	inPayload := compatibilityPayload{Compatibility: compatibilityLevel}
 	err := c.request(ctx, http.MethodPut, "config/", inPayload, &payload)
 	if err != nil {
 		return "", err
@@ -428,18 +423,16 @@ func (c *Client) PutCompatibilityLevelGlobal(
 	return payload.Compatibility, nil
 }
 
-/*
-method used to set the compatibility level of a subject.
-*/
+// PutCompatibilityLevel sets the compatibility level of a subject.
 func (c *Client) PutCompatibilityLevel(
 	ctx context.Context,
-	subject, compatibility_level string,
+	subject, compatibilityLevel string,
 ) (string, error) {
-	if !validCompatibilityLevel(compatibility_level) {
-		return "", errByInvalidCL(compatibility_level)
+	if !validCompatibilityLevel(compatibilityLevel) {
+		return "", errByInvalidCL(compatibilityLevel)
 	}
 	var payload compatibilityPayload
-	inPayload := compatibilityPayload{Compatibility: compatibility_level}
+	inPayload := compatibilityPayload{Compatibility: compatibilityLevel}
 	err := c.request(ctx, http.MethodPut, "config/"+subject, inPayload, &payload)
 	if err != nil {
 		return "", err
@@ -448,9 +441,7 @@ func (c *Client) PutCompatibilityLevel(
 	return payload.Compatibility, nil
 }
 
-/*
-method used to get the global compatibility level.
-*/
+// GetCompatibilityLevelGlobal gets the global compatibility level.
 func (c *Client) GetCompatibilityLevelGlobal(
 	ctx context.Context,
 ) (string, error) {
@@ -463,9 +454,7 @@ func (c *Client) GetCompatibilityLevelGlobal(
 	return payload.Compatibility, nil
 }
 
-/*
-method used to get the global compatibility level of a subject.
-*/
+// GetCompatibilityLevel gets the global compatibility level of a subject.
 func (c *Client) GetCompatibilityLevel(
 	ctx context.Context,
 	subject string,

--- a/registry/client_internal_test.go
+++ b/registry/client_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewClient_WithHTTPClient(t *testing.T) {
@@ -21,4 +22,20 @@ func TestNewClient_WithBasicAuth(t *testing.T) {
 	client, _ := NewClient("http://example.com", WithBasicAuth("username", "password"))
 
 	assert.Equal(t, client.creds, creds)
+}
+
+func TestFunc_validateCompatibilityLevel(t *testing.T) {
+	cls := []string{
+		BackwardCL,
+		BackwardTransitiveCL,
+		ForwardCL,
+		ForwardTransitiveCL,
+		FullCL,
+		FullTransitiveCL,
+		NoneCL,
+	}
+	for _, cl := range cls {
+		require.NoError(t, validateCompatibilityLevel(cl))
+	}
+	assert.Equal(t, "invalid compatibility level BOH", validateCompatibilityLevel("BOH").Error())
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -601,22 +601,6 @@ func TestError_ErrorEmptyMEssage(t *testing.T) {
 	assert.Equal(t, "registry error: 404", str)
 }
 
-func TestFunc_ValidateCompatibilityLevel(t *testing.T) {
-	cls := []string{
-		registry.BackwardCL,
-		registry.BackwardTransitiveCL,
-		registry.ForwardCL,
-		registry.ForwardTransitiveCL,
-		registry.FullCL,
-		registry.FullTransitiveCL,
-		registry.NoneCL,
-	}
-	for _, cl := range cls {
-		require.NoError(t, registry.ValidateCompatibilityLevel(cl))
-	}
-	assert.Equal(t, "invalid compatibility level BOH", registry.ValidateCompatibilityLevel("BOH").Error())
-}
-
 func TestClient_GetGlobalCompatibilityLevel(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -635,6 +635,18 @@ func TestClient_GetCompatibilityLevelGlobal(t *testing.T) {
 	assert.Equal(t, registry.FullCL, compatibilityLevel)
 }
 
+func TestClient_GetCompatibilityLevelGlobalError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	_, err := client.GetCompatibilityLevelGlobal(context.Background())
+
+	assert.Error(t, err)
+}
+
 func TestClient_GetCompatibilityLevel(t *testing.T) {
 	subject := "boh_subj"
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -654,6 +666,18 @@ func TestClient_GetCompatibilityLevel(t *testing.T) {
 	assert.Equal(t, registry.FullCL, compatibilityLevel)
 }
 
+func TestClient_GetCompatibilityLevelError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	_, err := client.GetCompatibilityLevel(context.Background(), "boh")
+
+	assert.Error(t, err)
+}
+
 func TestClient_PutCompatibilityLevelGlobal(t *testing.T) {
 	cl := registry.BackwardCL
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -669,6 +693,18 @@ func TestClient_PutCompatibilityLevelGlobal(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, cl, compatibilityLevel)
+}
+
+func TestClient_PutCompatibilityLevelGlobalError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	_, err := client.PutCompatibilityLevelGlobal(context.Background(), registry.BackwardCL)
+
+	assert.Error(t, err)
 }
 
 func TestClient_PutCompatibilityLevel(t *testing.T) {
@@ -687,4 +723,16 @@ func TestClient_PutCompatibilityLevel(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, cl, compatibilityLevel)
+}
+
+func TestClient_PutCompatibilityLevelError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	_, err := client.PutCompatibilityLevel(context.Background(), "boh", registry.BackwardCL)
+
+	assert.Error(t, err)
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -690,6 +690,22 @@ func TestClient_SetGlobalCompatibilityLevelError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestClient_SetGlobalCompatibilityLevelHandlesInvalidLevel(t *testing.T) {
+	invalid_cl := "INVALID_STUFF"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/config", r.URL.Path)
+
+		_, _ = w.Write([]byte((fmt.Sprintf("{\"compatibility\":\"%s\"}", invalid_cl))))
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	err := client.SetGlobalCompatibilityLevel(context.Background(), invalid_cl)
+
+	assert.Error(t, err)
+}
+
 func TestClient_SetCompatibilityLevel(t *testing.T) {
 	cl := registry.BackwardCL
 	subject := "boh_subj"
@@ -715,6 +731,23 @@ func TestClient_SetCompatibilityLevelError(t *testing.T) {
 	client, _ := registry.NewClient(s.URL)
 
 	err := client.SetCompatibilityLevel(context.Background(), "boh", registry.BackwardCL)
+
+	assert.Error(t, err)
+}
+
+func TestClient_SetCompatibilityLevelHandlesInvalidLevel(t *testing.T) {
+	invalid_cl := "INVALID_STUFF"
+	subject := "boh"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/config/"+subject, r.URL.Path)
+
+		_, _ = w.Write([]byte((fmt.Sprintf("{\"compatibility\":\"%s\"}", invalid_cl))))
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	err := client.SetCompatibilityLevel(context.Background(), subject, invalid_cl)
 
 	assert.Error(t, err)
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -617,7 +617,7 @@ func TestFunc_ValidateCompatibilityLevel(t *testing.T) {
 	assert.Equal(t, "invalid compatibility level BOH", registry.ValidateCompatibilityLevel("BOH").Error())
 }
 
-func TestClient_GetCompatibilityLevelGlobal(t *testing.T) {
+func TestClient_GetGlobalCompatibilityLevel(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		assert.Equal(t, "/config", r.URL.Path)
@@ -629,20 +629,20 @@ func TestClient_GetCompatibilityLevelGlobal(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	compatibilityLevel, err := client.GetCompatibilityLevelGlobal(context.Background())
+	compatibilityLevel, err := client.GetGlobalCompatibilityLevel(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, registry.FullCL, compatibilityLevel)
 }
 
-func TestClient_GetCompatibilityLevelGlobalError(t *testing.T) {
+func TestClient_GetGlobalCompatibilityLevelError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	_, err := client.GetCompatibilityLevelGlobal(context.Background())
+	_, err := client.GetGlobalCompatibilityLevel(context.Background())
 
 	assert.Error(t, err)
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -601,7 +601,7 @@ func TestError_ErrorEmptyMEssage(t *testing.T) {
 	assert.Equal(t, "registry error: 404", str)
 }
 
-func TestFunc_ValidCompatibilityLevel(t *testing.T) {
+func TestFunc_ValidateCompatibilityLevel(t *testing.T) {
 	cls := []string{
 		registry.BackwardCL,
 		registry.BackwardTransitiveCL,
@@ -612,9 +612,9 @@ func TestFunc_ValidCompatibilityLevel(t *testing.T) {
 		registry.NoneCL,
 	}
 	for _, cl := range cls {
-		assert.True(t, registry.ValidCompatibilityLevel(cl))
+		require.NoError(t, registry.ValidateCompatibilityLevel(cl))
 	}
-	assert.False(t, registry.ValidCompatibilityLevel("BOH"))
+	assert.Equal(t, "invalid compatibility level BOH", registry.ValidateCompatibilityLevel("BOH").Error())
 }
 
 func TestClient_GetCompatibilityLevelGlobal(t *testing.T) {

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -599,3 +599,40 @@ func TestError_ErrorEmptyMEssage(t *testing.T) {
 
 	assert.Equal(t, "registry error: 404", str)
 }
+
+func TestClient_GetCompatibilityLevelGlobal(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/config", r.URL.Path)
+
+		_, _ = w.Write([]byte(`{
+			"compatibility": "FULL"
+		  }`))
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	compatibilityLevel, err := client.GetCompatibilityLevelGlobal(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, registry.FullCL, compatibilityLevel)
+}
+
+func TestClient_GetCompatibilityLevel(t *testing.T) {
+	subject := "boh_subj"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/config/"+subject, r.URL.Path)
+
+		_, _ = w.Write([]byte(`{
+			"compatibility": "FULL"
+		  }`))
+	}))
+	defer s.Close()
+	client, _ := registry.NewClient(s.URL)
+
+	compatibilityLevel, err := client.GetCompatibilityLevel(context.Background(), subject)
+
+	require.NoError(t, err)
+	assert.Equal(t, registry.FullCL, compatibilityLevel)
+}

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -673,10 +673,9 @@ func TestClient_SetGlobalCompatibilityLevel(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	compatibilityLevel, err := client.SetGlobalCompatibilityLevel(context.Background(), cl)
+	err := client.SetGlobalCompatibilityLevel(context.Background(), cl)
 
 	require.NoError(t, err)
-	assert.Equal(t, cl, compatibilityLevel)
 }
 
 func TestClient_SetGlobalCompatibilityLevelError(t *testing.T) {
@@ -686,7 +685,7 @@ func TestClient_SetGlobalCompatibilityLevelError(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	_, err := client.SetGlobalCompatibilityLevel(context.Background(), registry.BackwardCL)
+	err := client.SetGlobalCompatibilityLevel(context.Background(), registry.BackwardCL)
 
 	assert.Error(t, err)
 }
@@ -703,10 +702,9 @@ func TestClient_SetCompatibilityLevel(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	compatibilityLevel, err := client.SetCompatibilityLevel(context.Background(), subject, cl)
+	err := client.SetCompatibilityLevel(context.Background(), subject, cl)
 
 	require.NoError(t, err)
-	assert.Equal(t, cl, compatibilityLevel)
 }
 
 func TestClient_SetCompatibilityLevelError(t *testing.T) {
@@ -716,7 +714,7 @@ func TestClient_SetCompatibilityLevelError(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	_, err := client.SetCompatibilityLevel(context.Background(), "boh", registry.BackwardCL)
+	err := client.SetCompatibilityLevel(context.Background(), "boh", registry.BackwardCL)
 
 	assert.Error(t, err)
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -678,7 +678,7 @@ func TestClient_GetCompatibilityLevelError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestClient_PutCompatibilityLevelGlobal(t *testing.T) {
+func TestClient_SetGlobalCompatibilityLevel(t *testing.T) {
 	cl := registry.BackwardCL
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "PUT", r.Method)
@@ -689,25 +689,25 @@ func TestClient_PutCompatibilityLevelGlobal(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	compatibilityLevel, err := client.PutCompatibilityLevelGlobal(context.Background(), cl)
+	compatibilityLevel, err := client.SetGlobalCompatibilityLevel(context.Background(), cl)
 
 	require.NoError(t, err)
 	assert.Equal(t, cl, compatibilityLevel)
 }
 
-func TestClient_PutCompatibilityLevelGlobalError(t *testing.T) {
+func TestClient_SetGlobalCompatibilityLevelError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	_, err := client.PutCompatibilityLevelGlobal(context.Background(), registry.BackwardCL)
+	_, err := client.SetGlobalCompatibilityLevel(context.Background(), registry.BackwardCL)
 
 	assert.Error(t, err)
 }
 
-func TestClient_PutCompatibilityLevel(t *testing.T) {
+func TestClient_SetCompatibilityLevel(t *testing.T) {
 	cl := registry.BackwardCL
 	subject := "boh_subj"
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -719,20 +719,20 @@ func TestClient_PutCompatibilityLevel(t *testing.T) {
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	compatibilityLevel, err := client.PutCompatibilityLevel(context.Background(), subject, cl)
+	compatibilityLevel, err := client.SetCompatibilityLevel(context.Background(), subject, cl)
 
 	require.NoError(t, err)
 	assert.Equal(t, cl, compatibilityLevel)
 }
 
-func TestClient_PutCompatibilityLevelError(t *testing.T) {
+func TestClient_SetCompatibilityLevelError(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
 	defer s.Close()
 	client, _ := registry.NewClient(s.URL)
 
-	_, err := client.PutCompatibilityLevel(context.Background(), "boh", registry.BackwardCL)
+	_, err := client.SetCompatibilityLevel(context.Background(), "boh", registry.BackwardCL)
 
 	assert.Error(t, err)
 }

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -601,6 +601,22 @@ func TestError_ErrorEmptyMEssage(t *testing.T) {
 	assert.Equal(t, "registry error: 404", str)
 }
 
+func TestFunc_ValidCompatibilityLevel(t *testing.T) {
+	cls := []string{
+		registry.BackwardCL,
+		registry.BackwardTransitiveCL,
+		registry.ForwardCL,
+		registry.ForwardTransitiveCL,
+		registry.FullCL,
+		registry.FullTransitiveCL,
+		registry.NoneCL,
+	}
+	for _, cl := range cls {
+		assert.True(t, registry.ValidCompatibilityLevel(cl))
+	}
+	assert.False(t, registry.ValidCompatibilityLevel("BOH"))
+}
+
 func TestClient_GetCompatibilityLevelGlobal(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)


### PR DESCRIPTION
Wrote code for compatibility level putting and getting. For the testing a bit of guidance would be well accepted! I usually set my tests with a container running, but I couldn't manage to run the whole zookeper+kafka_broker+confluent_schema_registry using [testcontainers-go](https://github.com/testcontainers/testcontainers-go)

Thanks for the attention,
Nuc