### PR TITLE
feat: extend validation for default enum value

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1270,7 +1270,24 @@ func isValidDefault(schema Schema, def any) (any, bool) {
 	case Null:
 		return nullDefault, def == nil
 
-	case String, Bytes, Enum, Fixed:
+	case Enum:
+		v, ok := def.(string)
+		if !ok || len(v) == 0 {
+			return def, false
+		}
+
+		enumSchema := schema.(*EnumSchema)
+		found := false
+		for i := range enumSchema.symbols {
+			if def == enumSchema.symbols[i] {
+				found = true
+				break
+			}
+		}
+
+		return def, found
+
+	case String, Bytes, Fixed:
 		if _, ok := def.(string); ok {
 			return def, true
 		}

--- a/schema_internal_test.go
+++ b/schema_internal_test.go
@@ -161,9 +161,27 @@ func TestIsValidDefault(t *testing.T) {
 				s, _ := NewEnumSchema("foo", "", []string{"BAR"})
 				return s
 			},
-			def:    "test",
-			want:   "test",
+			def:    "BAR",
+			want:   "BAR",
 			wantOk: true,
+		},
+		{
+			name: "Enum Invalid Default",
+			schemaFn: func() Schema {
+				s, _ := NewEnumSchema("foo", "", []string{"BAR"})
+				return s
+			},
+			def:    "BUP",
+			wantOk: false,
+		},
+		{
+			name: "Enum Empty string",
+			schemaFn: func() Schema {
+				s, _ := NewEnumSchema("foo", "", []string{"BAR"})
+				return s
+			},
+			def:    "",
+			wantOk: false,
 		},
 		{
 			name: "Enum Invalid Type",


### PR DESCRIPTION
Today I tried to figure out why the сlichhouse swears at my avro scheme. 
```avro
{
	"type": "record",
	"name": "Test",
	"fields": [
		{
			"name": "bup", 
			"type": {
				"type": "enum",
				"name": "some_type",
				"symbols": ["unspecified", "none", "basic", "bearer"]
			},
			"default": ""
		}
	]
}
```

The problem was in the default enum value. It can't be blank and must be equal to one of the provided values ("unspecified", "none", "basic", "bearer")
```avro
{
	"type": "record",
	"name": "Test",
	"fields": [
		{
			"name": "bup", 
			"type": {
				"type": "enum",
				"name": "some_type",
				"symbols": ["unspecified", "none", "basic", "bearer"]
			},
			"default": "unspecified"
		}
	]
}
```

I figured it out using http://avro.tarantool.org as it returns me error.
```json
[
  "Test/bup: Default value not valid (Not a some_type: )"
]
```