### PR TITLE
feat: use slab allocation for strings and bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,14 @@ At this moment recursive structs are not supported. It is planned for the future
 Benchmark source code can be found at: [https://github.com/nrwiersma/avro-benchmarks](https://github.com/nrwiersma/avro-benchmarks)
 
 ```
-BenchmarkGoAvroDecode-10       	  495176	      2413 ns/op	     418 B/op	      27 allocs/op
-BenchmarkGoAvroEncode-10       	  420168	      2917 ns/op	     948 B/op	      63 allocs/op
-BenchmarkGoGenAvroDecode-10    	  757150	      1552 ns/op	     728 B/op	      45 allocs/op
-BenchmarkGoGenAvroEncode-10    	 1882940	       639.0 ns/op	     256 B/op	       3 allocs/op
-BenchmarkHambaDecode-10        	 3138063	       383.0 ns/op	      64 B/op	       4 allocs/op
-BenchmarkHambaEncode-10        	 4377513	       273.3 ns/op	     112 B/op	       1 allocs/op
-BenchmarkLinkedinDecode-10     	 1000000	      1109 ns/op	    1688 B/op	      35 allocs/op
-BenchmarkLinkedinEncode-10     	 2641016	       456.0 ns/op	     248 B/op	       5 allocs/op
+BenchmarkGoAvroDecode-8      	  788455	      1505 ns/op	     418 B/op	      27 allocs/op
+BenchmarkGoAvroEncode-8      	  624343	      1908 ns/op	     806 B/op	      63 allocs/op
+BenchmarkGoGenAvroDecode-8   	 1360375	       876.4 ns/op	     320 B/op	      11 allocs/op
+BenchmarkGoGenAvroEncode-8   	 2801583	       425.9 ns/op	     240 B/op	       3 allocs/op
+BenchmarkHambaDecode-8       	 5046832	       238.7 ns/op	      47 B/op	       0 allocs/op
+BenchmarkHambaEncode-8       	 6017635	       196.2 ns/op	     112 B/op	       1 allocs/op
+BenchmarkLinkedinDecode-8    	 1000000	      1003 ns/op	    1688 B/op	      35 allocs/op
+BenchmarkLinkedinEncode-8    	 3170553	       381.5 ns/op	     248 B/op	       5 allocs/op
 ```
 
 Always benchmark with your own workload. The result depends heavily on the data input.

--- a/decoder_fixed_test.go
+++ b/decoder_fixed_test.go
@@ -123,7 +123,6 @@ func TestDecoder_FixedLogicalDurationSizeNot12(t *testing.T) {
 	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
 	require.NoError(t, err)
 
-	fmt.Printf("decoder: starting test\n")
 	got := avro.LogicalDuration{}
 	err = dec.Decode(&got)
 	assert.Error(t, err)

--- a/reader.go
+++ b/reader.go
@@ -206,7 +206,7 @@ func (r *Reader) ReadBytes() []byte {
 // ReadString reads a String from the Reader.
 func (r *Reader) ReadString() string {
 	b := r.readBytes("string")
-	if b == nil {
+	if b == nil || len(b) == 0 {
 		return ""
 	}
 
@@ -219,10 +219,13 @@ func (r *Reader) readBytes(typ string) []byte {
 		r.ReportError("ReadString", "invalid "+typ+" length")
 		return nil
 	}
+	if size == 0 {
+		return []byte{}
+	}
 
 	// The bytes are entirely in the buffer and of a reasonable size.
 	// Use the byte slab.
-	if r.head+size <= r.tail && size <= 1024 && size > 0 {
+	if r.head+size <= r.tail && size <= 1024 {
 		if cap(r.slab) < size {
 			r.slab = make([]byte, 1024)
 		}

--- a/reader.go
+++ b/reader.go
@@ -206,7 +206,7 @@ func (r *Reader) ReadBytes() []byte {
 // ReadString reads a String from the Reader.
 func (r *Reader) ReadString() string {
 	b := r.readBytes("string")
-	if b == nil || len(b) == 0 {
+	if len(b) == 0 {
 		return ""
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -213,10 +213,10 @@ func (r *Reader) ReadString() string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
-func (r *Reader) readBytes(typ string) []byte {
+func (r *Reader) readBytes(op string) []byte {
 	size := int(r.ReadLong())
 	if size < 0 {
-		r.ReportError("ReadString", "invalid "+typ+" length")
+		r.ReportError("ReadString", "invalid "+op+" length")
 		return nil
 	}
 	if size == 0 {


### PR DESCRIPTION
This PR adds support for slab allocation for strings and bytes smaller than 1024 bytes, but will likely be all of them.
This creates a new fast path and centralises the read code, and it is now basically identical.

The benchmarked changes are as follows:
```
name                      old time/op    new time/op    delta
SuperheroDecode-8            281ns ± 0%     245ns ± 2%   -12.81%  (p=0.000 n=8+10)
SuperheroEncode-8            202ns ± 1%     203ns ± 3%      ~     (p=0.255 n=10+10)
PartialSuperheroDecode-8     119ns ± 1%     111ns ± 1%    -6.82%  (p=0.000 n=10+10)
SuperheroGenericDecode-8    1.44µs ± 1%    1.38µs ± 0%    -3.63%  (p=0.000 n=9+9)
SuperheroGenericEncode-8     258ns ± 1%     278ns ± 1%    +7.84%  (p=0.000 n=9+9)
SuperheroWriteFlush-8        167ns ± 1%     169ns ± 1%    +1.06%  (p=0.023 n=9+10)

name                      old alloc/op   new alloc/op   delta
SuperheroDecode-8            64.0B ± 0%     47.0B ± 0%   -26.56%  (p=0.000 n=10+10)
SuperheroEncode-8             112B ± 0%      112B ± 0%      ~     (all equal)
PartialSuperheroDecode-8     16.0B ± 0%      9.0B ± 0%   -43.75%  (p=0.000 n=10+10)
SuperheroGenericDecode-8    1.70kB ± 0%    1.68kB ± 0%    -1.00%  (p=0.000 n=10+10)
SuperheroGenericEncode-8     80.0B ± 0%     80.0B ± 0%      ~     (all equal)
SuperheroWriteFlush-8        0.00B          0.00B           ~     (all equal)

name                      old allocs/op  new allocs/op  delta
SuperheroDecode-8             4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
SuperheroEncode-8             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
PartialSuperheroDecode-8      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
SuperheroGenericDecode-8      33.0 ± 0%      29.0 ± 0%   -12.12%  (p=0.000 n=10+10)
SuperheroGenericEncode-8      3.00 ± 0%      3.00 ± 0%      ~     (all equal)
SuperheroWriteFlush-8         0.00           0.00           ~     (all equal)
```