### PR TITLE
Ability to serialize uint64 values as fixed-length entries:

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ More examples in the [godoc](https://godoc.org/github.com/hamba/avro).
 | `double`                | `float64`                                              | `float64`                |
 | `long`                  | `int64`, `uint32`\*                                    | `int64`, `uint32`        |
 | `int`                   | `int`, `int32`, `int16`, `int8`, `uint8`\*, `uint16`\* | `int`, `uint8`, `uint16` |
+| `fixed`                 | `uint64`                                               | `uint64`                 |
 | `string`                | `string`                                               | `string`                 |
 | `array`                 | `[]T`                                                  | `[]any`          |
 | `enum`                  | `string`                                               | `string`                 |

--- a/decoder_fixed_test.go
+++ b/decoder_fixed_test.go
@@ -3,6 +3,7 @@ package avro_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -127,4 +128,31 @@ func TestDecoder_FixedLogicalDurationSizeNot12(t *testing.T) {
 	err = dec.Decode(&got)
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("avro: avro.LogicalDuration is unsupported for Avro fixed, size=11"), err)
+}
+
+func TestDecoder_FixedUint64_Full(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	schema := `{"type":"fixed", "name": "test", "size": 8}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got uint64
+	err = dec.Decode(&got)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(math.MaxUint64), got)
+}
+func TestDecoder_FixedUint64_Simple(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}
+	schema := `{"type":"fixed", "name": "test", "size": 8}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got uint64
+	err = dec.Decode(&got)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(256), got)
 }

--- a/encoder_fixed_test.go
+++ b/encoder_fixed_test.go
@@ -3,6 +3,7 @@ package avro_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -120,4 +121,32 @@ func TestEncoder_FixedLogicalDurationSizeNot12(t *testing.T) {
 	err = enc.Encode(duration)
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("avro: avro.LogicalDuration is unsupported for Avro fixed, size=11"), err)
+}
+
+func TestEncoder_FixedUint64_Full(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"fixed", "name": "test", "size": 8}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode(uint64(math.MaxUint64))
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, buf.Bytes())
+}
+
+func TestEncoder_FixedUint64_Small(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"fixed", "name": "test", "size": 8}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode(uint64(256))
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}, buf.Bytes())
 }


### PR DESCRIPTION
This pull request adds the ability to fully express native, uint64 values as fixed-length records within Avro.

See https://stackoverflow.com/a/75242092/151741 for more details.