### PR TITLE
fix: generic read of fixed

### DIFF
--- a/reader_generic.go
+++ b/reader_generic.go
@@ -2,6 +2,7 @@ package avro
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 )
 
@@ -118,7 +119,7 @@ func (r *Reader) ReadNext(schema Schema) any {
 			dec := ls.(*DecimalLogicalSchema)
 			return ratFromBytes(obj, dec.Scale())
 		}
-		return obj
+		return byteSliceToArray(obj, size)
 	default:
 		r.ReportError("Read", fmt.Sprintf("unexpected schema type: %v", schema.Type()))
 		return nil
@@ -151,4 +152,12 @@ func (r *Reader) ReadMapCB(fn func(*Reader, string) bool) {
 			fn(r, field)
 		}
 	}
+}
+
+var byteType = reflect.TypeOf((*byte)(nil)).Elem()
+
+func byteSliceToArray(b []byte, size int) any {
+	vArr := reflect.New(reflect.ArrayOf(size, byteType)).Elem()
+	reflect.Copy(vArr, reflect.ValueOf(b))
+	return vArr.Interface()
 }

--- a/reader_generic_test.go
+++ b/reader_generic_test.go
@@ -185,7 +185,7 @@ func TestReader_ReadNext(t *testing.T) {
 			name:    "Fixed",
 			data:    []byte{0x66, 0x6F, 0x6F, 0x66, 0x6F, 0x6F},
 			schema:  `{"type":"fixed", "name": "test", "size": 6}`,
-			want:    []byte{'f', 'o', 'o', 'f', 'o', 'o'},
+			want:    [6]byte{'f', 'o', 'o', 'f', 'o', 'o'},
 			wantErr: require.NoError,
 		},
 		{


### PR DESCRIPTION
This fixes an issue with generic reading of Fixed type that returned a byte slice instead of a byte array.

Fixes #285