### PR TITLE
fix: disallow duplicate names

### DIFF
--- a/decoder_enum_test.go
+++ b/decoder_enum_test.go
@@ -103,13 +103,14 @@ func TestDecoder_EnumTextUnmarshalerObj(t *testing.T) {
 	"type": "record",
 	"name": "test",
 	"fields" : [
-		{"name": "a", "type": {"type":"enum", "name": "test", "symbols": ["foo", "bar"]}}
+		{"name": "a", "type": {"type":"enum", "name": "test1", "symbols": ["foo", "bar"]}}
     ]
 }`
-	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
 
 	var got testEnumUnmarshalerObj
-	err := dec.Decode(&got)
+	err = dec.Decode(&got)
 
 	require.NoError(t, err)
 	require.NotNil(t, got)

--- a/encoder_enum_test.go
+++ b/encoder_enum_test.go
@@ -87,7 +87,7 @@ func TestEncoder_EnumTextMarshalerObj(t *testing.T) {
 	"type": "record",
 	"name": "test",
 	"fields" : [
-		{"name": "a", "type": {"type":"enum", "name": "test", "symbols": ["foo", "bar"]}}
+		{"name": "a", "type": {"type":"enum", "name": "test1", "symbols": ["foo", "bar"]}}
     ]
 }`
 	buf := bytes.NewBuffer([]byte{})

--- a/schema_test.go
+++ b/schema_test.go
@@ -1264,6 +1264,30 @@ func TestSchema_MultiFile(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestSchema_DoesNotAllowDuplicateFullNames(t *testing.T) {
+	schm := `
+{
+   "type": "record",
+   "name": "Interop",
+   "namespace": "org.hamba.avro",
+   "fields": [
+       {
+           "name": "intField",
+           "type": {
+             "type": "record",
+             "name": "Interop",
+             "fields": []
+           }
+       }
+  ]
+}
+`
+
+	_, err := avro.Parse(schm)
+
+	assert.Error(t, err)
+}
+
 func TestSchema_Interop(t *testing.T) {
 	schm := `
 {


### PR DESCRIPTION
This PR disallows duplicate full names in a single schema. It does not check against external previously cached schemas.

Fixes #295