### PR TITLE
feat: add stdout output support to avrogen

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Example usage assuming there's a valid schema in `in.avsc`:
 avrogen -pkg avro -o bla.go -tags json:snake,yaml:upper-camel in.avsc
 ```
 
-**Tip:** Omit `-o FILE` to dump the generated schema to stdout instead of a file.
+**Tip:** Omit `-o FILE` to dump the generated Go structs to stdout instead of a file.
 
 Check the options and usage with `-h`:
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Example usage assuming there's a valid schema in `in.avsc`:
 avrogen -pkg avro -o bla.go -tags json:snake,yaml:upper-camel in.avsc
 ```
 
+**Tip:** Omit `-o FILE` to dump the generated schema to stdout instead of a file.
+
 Check the options and usage with `-h`:
 
 ```shell

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -81,22 +81,19 @@ func realMain(args []string, out, dumpout io.Writer) int {
 
 	writer := dumpout
 	if cfg.Out != "" {
-		if writer, err = os.Create(cfg.Out); err != nil {
+		file, err := os.Create(cfg.Out)
+		if err != nil {
 			_, _ = fmt.Fprintf(out, "Error: could not create output file: %v\n", err)
 			return 4
 		}
+		defer func() { _ = file.Close() }()
+
+		writer = file
 	}
 
 	if _, err := writer.Write(formatted); err != nil {
 		_, _ = fmt.Fprintf(out, "Error: could not write code: %v\n", err)
 		return 4
-	}
-
-	if f, ok := writer.(*os.File); ok {
-		if err := f.Close(); err != nil {
-			_, _ = fmt.Fprintf(out, "Error: could not close output file: %v\n", err)
-			return 4
-		}
 	}
 
 	return 0

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -79,17 +79,26 @@ func realMain(args []string, out, dumpout io.Writer) int {
 		return 3
 	}
 
-	if cfg.Out == "" {
-		if _, err = dumpout.Write(formatted); err != nil {
-			_, _ = fmt.Fprintf(out, "Error: could not write to stdout: %v\n", err)
-			return 4
-		}
-	} else {
-		if err = os.WriteFile(cfg.Out, formatted, 0o600); err != nil {
-			_, _ = fmt.Fprintf(out, "Error: could not write file: %v\n", err)
+	writer := dumpout
+	if cfg.Out != "" {
+		if writer, err = os.Create(cfg.Out); err != nil {
+			_, _ = fmt.Fprintf(out, "Error: could not create output file: %v\n", err)
 			return 4
 		}
 	}
+
+	if _, err := writer.Write(formatted); err != nil {
+		_, _ = fmt.Fprintf(out, "Error: could not write code: %v\n", err)
+		return 4
+	}
+
+	if f, ok := writer.(*os.File); ok {
+		if err := f.Close(); err != nil {
+			_, _ = fmt.Fprintf(out, "Error: could not close output file: %v\n", err)
+			return 4
+		}
+	}
+
 	return 0
 }
 

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -80,7 +80,10 @@ func realMain(args []string, out, dumpout io.Writer) int {
 	}
 
 	if cfg.Out == "" {
-		dumpout.Write(formatted)
+		if _, err = dumpout.Write(formatted); err != nil {
+			_, _ = fmt.Fprintf(out, "Error: could not write to stdout: %v\n", err)
+			return 4
+		}
 	} else {
 		if err = os.WriteFile(cfg.Out, formatted, 0o600); err != nil {
 			_, _ = fmt.Fprintf(out, "Error: could not write file: %v\n", err)

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -31,7 +31,7 @@ func realMain(args []string, out, dumpout io.Writer) int {
 	flgs := flag.NewFlagSet("avrogen", flag.ExitOnError)
 	flgs.SetOutput(out)
 	flgs.StringVar(&cfg.Pkg, "pkg", "", "The package name of the output file.")
-	flgs.StringVar(&cfg.Out, "o", "", "The output file path (dump to stdout if not provided).")
+	flgs.StringVar(&cfg.Out, "o", "", "The output file path to write to instead of stdout.")
 	flgs.StringVar(&cfg.Tags, "tags", "", "The additional field tags <tag-name>:{snake|camel|upper-camel|kebab}>[,...]")
 	flgs.BoolVar(&cfg.FullName, "fullname", false, "Use the full name of the Record schema to create the struct name.")
 	flgs.BoolVar(&cfg.Encoders, "encoders", false, "Generate encoders for the structs.")

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -23,15 +23,15 @@ type config struct {
 }
 
 func main() {
-	os.Exit(realMain(os.Args, os.Stderr))
+	os.Exit(realMain(os.Args, os.Stderr, os.Stdout))
 }
 
-func realMain(args []string, out io.Writer) int {
+func realMain(args []string, out, dumpout io.Writer) int {
 	var cfg config
 	flgs := flag.NewFlagSet("avrogen", flag.ExitOnError)
 	flgs.SetOutput(out)
 	flgs.StringVar(&cfg.Pkg, "pkg", "", "The package name of the output file.")
-	flgs.StringVar(&cfg.Out, "o", "", "The output file path.")
+	flgs.StringVar(&cfg.Out, "o", "", "The output file path (dump to stdout if not provided).")
 	flgs.StringVar(&cfg.Tags, "tags", "", "The additional field tags <tag-name>:{snake|camel|upper-camel|kebab}>[,...]")
 	flgs.BoolVar(&cfg.FullName, "fullname", false, "Use the full name of the Record schema to create the struct name.")
 	flgs.BoolVar(&cfg.Encoders, "encoders", false, "Generate encoders for the structs.")
@@ -75,12 +75,17 @@ func realMain(args []string, out io.Writer) int {
 	}
 	formatted, err := format.Source(buf.Bytes())
 	if err != nil {
-		_, _ = fmt.Fprintf(out, "Error: could format code: %v\n", err)
+		_, _ = fmt.Fprintf(out, "Error: could not format code: %v\n", err)
 		return 3
 	}
-	if err = os.WriteFile(cfg.Out, formatted, 0o600); err != nil {
-		_, _ = fmt.Fprintf(out, "Error: could write file: %v\n", err)
-		return 4
+
+	if cfg.Out == "" {
+		dumpout.Write(formatted)
+	} else {
+		if err = os.WriteFile(cfg.Out, formatted, 0o600); err != nil {
+			_, _ = fmt.Fprintf(out, "Error: could not write file: %v\n", err)
+			return 4
+		}
 	}
 	return 0
 }
@@ -92,10 +97,6 @@ func validateOpts(nargs int, cfg config) error {
 
 	if cfg.Pkg == "" {
 		return fmt.Errorf("a package is required")
-	}
-
-	if cfg.Out == "" {
-		return fmt.Errorf("an output file is reqired")
 	}
 
 	return nil


### PR DESCRIPTION
Hello, this small PR adds support for stdout output to `avrogen`.
It is implemented by making the `-o FILE` argument optional, writing the generated Go code to stdout if not provided.

I updated the unit tests accordingly and fixed some wrong wording in error messages as well 👍.

The use case for this feature is quick debugging of Go structs generation without having to use temporary files.