### PR TITLE
feat: add custom initialisms support to gen package and avrogen

### DIFF
--- a/cmd/avrogen/main_test.go
+++ b/cmd/avrogen/main_test.go
@@ -172,3 +172,41 @@ func TestParseTags(t *testing.T) {
 		})
 	}
 }
+
+func TestParseInitialisms(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialisms string
+		wantErr     bool
+	}{
+		{
+			name:        "single initialism",
+			initialisms: "ABC",
+			wantErr:     false,
+		},
+		{
+			name:        "multiple initialisms",
+			initialisms: "ABC,DEF",
+			wantErr:     false,
+		},
+		{
+			name:        "wrong initialism",
+			initialisms: "ABC,def,GHI",
+			wantErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseInitialisms(test.initialisms)
+
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/cmd/avrogen/main_test.go
+++ b/cmd/avrogen/main_test.go
@@ -177,22 +177,22 @@ func TestParseInitialisms(t *testing.T) {
 	tests := []struct {
 		name        string
 		initialisms string
-		wantErr     bool
+		errFunc     assert.ErrorAssertionFunc
 	}{
 		{
 			name:        "single initialism",
 			initialisms: "ABC",
-			wantErr:     false,
+			errFunc:     assert.NoError,
 		},
 		{
 			name:        "multiple initialisms",
 			initialisms: "ABC,DEF",
-			wantErr:     false,
+			errFunc:     assert.NoError,
 		},
 		{
 			name:        "wrong initialism",
 			initialisms: "ABC,def,GHI",
-			wantErr:     true,
+			errFunc:     assert.Error,
 		},
 	}
 
@@ -201,12 +201,7 @@ func TestParseInitialisms(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := parseInitialisms(test.initialisms)
 
-			if test.wantErr {
-				assert.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
+			test.errFunc(t, err)
 		})
 	}
 }

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -75,6 +75,24 @@ func TestStruct_HandlesGoInitialisms(t *testing.T) {
 	assert.Contains(t, lines, "type HTTPRecord struct {")
 }
 
+func TestStruct_HandlesAdditionalInitialisms(t *testing.T) {
+	schema := `{
+  "type": "record",
+  "name": "CidOverHttpRecord",
+  "fields": [
+    { "name": "someString", "type": "string" }
+  ]
+}`
+	gc := gen.Config{
+		PackageName: "Something",
+		Initialisms: []string{"CID"},
+	}
+
+	_, lines := generate(t, schema, gc)
+
+	assert.Contains(t, lines, "type CIDOverHTTPRecord struct {")
+}
+
 func TestStruct_ConfigurableFieldTags(t *testing.T) {
 	schema := `{
   "type": "record",


### PR DESCRIPTION
Hello, this simple PR adds support for custom initialisms to the `gen` package and `avrogen` command.

Additional custom initialisms are necessary because `strcase.ToGoPascal` only uses GoLint's list of initialisms.
Currently, if an initialism in struct/field names is not part of Golint's, then `strcase` wrongly downcases it.

For example, consider the following schema containing the domain initialism `AID`:
```json
{
  "type": "record",
  "name": "AIDEventHTTPService",
  "namespace": "example",
  "fields" : [
    {"name": "AIDNumber", "type": "long"},
    {"name": "Desc", "type": "string"}
  ]
}

```

Currently, `avrogen` generates the following Go struct (struct/field names: `AID` -> `Aid`):
```go
package example

// Code generated by avro/gen. DO NOT EDIT.

// AidEventHTTPService is a generated struct.
type AidEventHTTPService struct {
        AidNumber int64  `avro:"AIDNumber"`
        Desc      string `avro:"Desc"`
}
```

With this PR, `-initialisms AID` can be given to `avrogen` to generate the correct struct/field names:
```go
package example

// Code generated by avro/gen. DO NOT EDIT.

// AIDEventHTTPService is a generated struct.
type AIDEventHTTPService struct {
        AIDNumber int64  `avro:"AIDNumber"`
        Desc      string `avro:"Desc"`
}
```

There is a related PR in the upstream `strcase` repository: <https://github.com/ettle/strcase/pull/13>
That PR allows to preserve any extra initialisms without having to define them in advance, however the maintainers seems to not be merging it any time soon. This PR allows to solve the issue in the mean time.
