### PR TITLE
fix: check exit code in avrogen required flags tests

### DIFF
--- a/cmd/avrogen/main_test.go
+++ b/cmd/avrogen/main_test.go
@@ -16,39 +16,39 @@ var update = flag.Bool("update", false, "Update golden files")
 
 func TestAvroGen_RequiredFlags(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		exitCode int
+		name         string
+		args         []string
+		wantExitCode int
 	}{
 		{
-			name:     "validates schema is set",
-			args:     []string{"avrogen", "-pkg", "test", "-o", "some/file"},
-			exitCode: 1,
+			name:         "validates schema is set",
+			args:         []string{"avrogen", "-pkg", "test", "-o", "some/file"},
+			wantExitCode: 1,
 		},
 		{
-			name:     "validates schema exists",
-			args:     []string{"avrogen", "-pkg", "test", "-o", "some/file", "some/schema"},
-			exitCode: 2,
+			name:         "validates schema exists",
+			args:         []string{"avrogen", "-pkg", "test", "-o", "some/file", "some/schema"},
+			wantExitCode: 2,
 		},
 		{
-			name:     "validates package is set",
-			args:     []string{"avrogen", "-o", "some/file", "schema.avsc"},
-			exitCode: 1,
+			name:         "validates package is set",
+			args:         []string{"avrogen", "-o", "some/file", "schema.avsc"},
+			wantExitCode: 1,
 		},
 		{
-			name:     "validates tag format are valid",
-			args:     []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "snake", "schema.avsc"},
-			exitCode: 1,
+			name:         "validates tag format are valid",
+			args:         []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "snake", "schema.avsc"},
+			wantExitCode: 1,
 		},
 		{
-			name:     "validates tag key are valid",
-			args:     []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", ":snake", "schema.avsc"},
-			exitCode: 1,
+			name:         "validates tag key are valid",
+			args:         []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", ":snake", "schema.avsc"},
+			wantExitCode: 1,
 		},
 		{
-			name:     "validates tag style are valid",
-			args:     []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "json:something", "schema.avsc"},
-			exitCode: 1,
+			name:         "validates tag style are valid",
+			args:         []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "json:something", "schema.avsc"},
+			wantExitCode: 1,
 		},
 	}
 
@@ -57,7 +57,7 @@ func TestAvroGen_RequiredFlags(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := realMain(test.args, io.Discard, io.Discard)
 
-			assert.Equal(t, test.exitCode, got)
+			assert.Equal(t, test.wantExitCode, got)
 		})
 	}
 }

--- a/cmd/avrogen/main_test.go
+++ b/cmd/avrogen/main_test.go
@@ -16,39 +16,39 @@ var update = flag.Bool("update", false, "Update golden files")
 
 func TestAvroGen_RequiredFlags(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr bool
+		name     string
+		args     []string
+		exitCode int
 	}{
 		{
-			name:    "validates schema is set",
-			args:    []string{"avrogen", "-pkg", "test", "-o", "some/file"},
-			wantErr: true,
+			name:     "validates schema is set",
+			args:     []string{"avrogen", "-pkg", "test", "-o", "some/file"},
+			exitCode: 1,
 		},
 		{
-			name:    "validates schema exists",
-			args:    []string{"avrogen", "-pkg", "test", "-o", "some/file", "some/schema"},
-			wantErr: true,
+			name:     "validates schema exists",
+			args:     []string{"avrogen", "-pkg", "test", "-o", "some/file", "some/schema"},
+			exitCode: 2,
 		},
 		{
-			name:    "validates package is set",
-			args:    []string{"avrogen", "-o", "some/file", "schema.avsc"},
-			wantErr: true,
+			name:     "validates package is set",
+			args:     []string{"avrogen", "-o", "some/file", "schema.avsc"},
+			exitCode: 1,
 		},
 		{
-			name:    "validates tag format are valid",
-			args:    []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "snake", "schema.avsc"},
-			wantErr: true,
+			name:     "validates tag format are valid",
+			args:     []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "snake", "schema.avsc"},
+			exitCode: 1,
 		},
 		{
-			name:    "validates tag key are valid",
-			args:    []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", ":snake", "schema.avsc"},
-			wantErr: true,
+			name:     "validates tag key are valid",
+			args:     []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", ":snake", "schema.avsc"},
+			exitCode: 1,
 		},
 		{
-			name:    "validates tag style are valid",
-			args:    []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "json:something", "schema.avsc"},
-			wantErr: true,
+			name:     "validates tag style are valid",
+			args:     []string{"avrogen", "-o", "some/file", "-pkg", "test", "-tags", "json:something", "schema.avsc"},
+			exitCode: 1,
 		},
 	}
 
@@ -57,12 +57,7 @@ func TestAvroGen_RequiredFlags(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := realMain(test.args, io.Discard, io.Discard)
 
-			if !test.wantErr {
-				assert.Equal(t, 0, got)
-				return
-			}
-
-			assert.NotEqual(t, 0, got)
+			assert.Equal(t, test.exitCode, got)
 		})
 	}
 }


### PR DESCRIPTION
While working on PR #302, I realized that the unit tests did _not_ fail when I removed the requirement for `-o FILE`.
The reason is that the unit tests were expecting errors but not _which_ errors. When I removed the requirement for `-o FILE`, the test still passed because `realMain` still failed but for a different reason (schema not found).

This PR fixes the avrogen required flags unit tests by checking the actual exit code returned from `realMain`.