### PR TITLE
Allow tag style "original" for additional tags

### DIFF
--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -146,6 +146,8 @@ func parseTags(raw string) (map[string]gen.TagStyle, error) {
 			style = gen.Kebab
 		case string(gen.Snake):
 			style = gen.Snake
+		case string(gen.Original):
+			style = gen.Original
 		default:
 			return nil, fmt.Errorf("style %q is invalid in %q", parts[1], tag)
 		}

--- a/cmd/avrogen/main_test.go
+++ b/cmd/avrogen/main_test.go
@@ -164,6 +164,10 @@ func TestParseTags(t *testing.T) {
 			name: "kebab case",
 			tags: "json:kebab",
 		},
+		{
+			name: "original case",
+			tags: "json:original",
+		},
 	}
 
 	for _, test := range tests {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -27,6 +27,8 @@ type Config struct {
 type TagStyle string
 
 const (
+	// Original is a style like whAtEVer_IS_InthEInpuT.
+	Original TagStyle = "original"
 	// Snake is a style like im_written_in_snake_case.
 	Snake TagStyle = "snake"
 	// Camel is a style like imWrittenInCamelCase.
@@ -355,6 +357,8 @@ func formatTag(tag string, style TagStyle) string {
 		return strcase.ToCamel(tag)
 	case Snake:
 		return strcase.ToSnake(tag)
+	case Original:
+		fallthrough
 	default:
 		return tag
 	}

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -98,7 +98,7 @@ func TestStruct_ConfigurableFieldTags(t *testing.T) {
   "type": "record",
   "name": "test",
   "fields": [
-    { "name": "someString", "type": "string" }
+    { "name": "someSTRING", "type": "string" }
   ]
 }`
 
@@ -110,7 +110,8 @@ func TestStruct_ConfigurableFieldTags(t *testing.T) {
 		{tagStyle: gen.Snake, expectedTag: "json:\"some_string\""},
 		{tagStyle: gen.Kebab, expectedTag: "json:\"some-string\""},
 		{tagStyle: gen.UpperCamel, expectedTag: "json:\"SomeString\""},
-		{tagStyle: gen.TagStyle(""), expectedTag: "json:\"someString\""},
+		{tagStyle: gen.Original, expectedTag: "json:\"someSTRING\""},
+		{tagStyle: gen.TagStyle(""), expectedTag: "json:\"someSTRING\""},
 	}
 
 	for _, test := range tests {
@@ -127,7 +128,7 @@ func TestStruct_ConfigurableFieldTags(t *testing.T) {
 			for _, expected := range []string{
 				"package something",
 				"type Test struct {",
-				"SomeString string `avro:\"someString\" " + test.expectedTag + "`",
+				"SomeString string `avro:\"someSTRING\" " + test.expectedTag + "`",
 				"}",
 			} {
 				assert.Contains(t, lines, expected)


### PR DESCRIPTION
Some edge cases require using the tag style from avro as-is for other formats.
The tag style `original` explicitly does not do any processing on the tag before code generation.

This is mostly already supported in the code generation, but the CLI options would reject
any configuration value which would trigger this behaviour.