### PR TITLE
feat: support TextMarshaller for map key

### DIFF
--- a/encoder_map_test.go
+++ b/encoder_map_test.go
@@ -2,6 +2,8 @@ package avro_test
 
 import (
 	"bytes"
+	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/hamba/avro/v2"
@@ -112,4 +114,78 @@ func TestEncoder_MapWithMoreThanBlockLengthKeys(t *testing.T) {
 		barfoo := bytes.Equal([]byte{0x01, 0x0a, 0x06, 0x62, 0x61, 0x72, 0x04, 0x01, 0x0a, 0x06, 0x66, 0x6F, 0x6F, 0x02, 0x0}, buf.Bytes())
 		return (foobar || barfoo)
 	})
+}
+
+type textMarshallerInt int
+
+func (t textMarshallerInt) MarshalText() (text []byte, err error) {
+	return []byte(strconv.Itoa(int(t))), nil
+}
+
+type textMarshallerError int
+
+func (t textMarshallerError) MarshalText() (text []byte, err error) {
+	return nil, errors.New("test")
+}
+
+func TestEncoder_MapMarshaller(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"map", "values": "string"}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode(map[textMarshallerInt]string{
+		1: "test",
+	})
+
+	require.NoError(t, err)
+	want := []byte{0x1, 0xe, 0x2, 0x31, 0x8, 0x74, 0x65, 0x73, 0x74, 0x0}
+	assert.Equal(t, want, buf.Bytes())
+}
+
+func TestEncoder_MapMarshallerNil(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"map", "values": "string"}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode(map[*textMarshallerError]int{
+		nil: 1,
+	})
+
+	require.Error(t, err)
+}
+
+func TestEncoder_MapMarshallerKeyError(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"map", "values": "string"}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode(map[textMarshallerError]int{
+		1: 1,
+	})
+
+	require.Error(t, err)
+}
+
+func TestEncoder_MapMarshallerError(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"map", "values": "string"}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode(map[textMarshallerInt]int{
+		1: 1,
+	})
+
+	require.Error(t, err)
 }


### PR DESCRIPTION
This PR adds support to TextMarshaller/TextUnmarshaller for Map keys.

**Note:** For this to work on the decode, the type used must be a pointer in order to implement the TextUnmarshaller interface.

Fixes #327