### PR TITLE
fix: correct godoc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fmt.Println(out)
 // Outputs: {27 foo}
 ```
 
-More examples in the [godoc](https://godoc.org/github.com/hamba/avro).
+More examples in the [godoc](https://godoc.org/github.com/hamba/avro/v2).
 
 #### Types Conversions
 


### PR DESCRIPTION
This short PR fixes an outdated godoc link in the README file.
The previous link was pointing to the older v1 branch of the library.