### PR TITLE
Make defaultMaxByteSliceSize equal to 1 MiB

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modern-go/reflect2"
 )
 
-const maxByteSliceSize = 1024 * 1024
+const defaultMaxByteSliceSize = 1_048_576 // 1 MiB
 
 // DefaultConfig is the default API.
 var DefaultConfig = Config{}.Freeze()
@@ -262,7 +262,7 @@ func (c *frozenConfig) getBlockLength() int {
 func (c *frozenConfig) getMaxByteSliceSize() int {
 	size := c.config.MaxByteSliceSize
 	if size == 0 {
-		return maxByteSliceSize
+		return defaultMaxByteSliceSize
 	}
 	return size
 }


### PR DESCRIPTION
According to the documentation, set the default value of max byte slice to 1 MiB.
Minor refactoring of the constant's name.

Close #341 
