### PR TITLE
feat: optimise generic decodes

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -86,13 +86,13 @@ func decoderOfType(cfg *frozenConfig, schema Schema, typ reflect2.Type) ValDecod
 	// Handle eface case when it isnt a union
 	if typ.Kind() == reflect.Interface && schema.Type() != Union {
 		if _, ok := typ.(*reflect2.UnsafeIFaceType); !ok {
-			return &efaceDecoder{schema: schema}
+			return newEfaceDecoder(cfg, schema)
 		}
 	}
 
 	switch schema.Type() {
 	case String, Bytes, Int, Long, Float, Double, Boolean:
-		return createDecoderOfNative(schema, typ)
+		return createDecoderOfNative(schema.(*PrimitiveSchema), typ)
 
 	case Record:
 		return createDecoderOfRecord(cfg, schema, typ)

--- a/codec_generic.go
+++ b/codec_generic.go
@@ -1,124 +1,121 @@
 package avro
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
 	"time"
-	"unsafe"
 
 	"github.com/modern-go/reflect2"
 )
 
-func genericDecode(schema Schema, r *Reader) any {
-	rPtr, rTyp, err := genericReceiver(schema)
-	if err != nil {
-		r.ReportError("Read", err.Error())
-		return nil
-	}
-	decoderOfType(r.cfg, schema, rTyp).Decode(rPtr, r)
+func genericDecode(typ reflect2.Type, dec ValDecoder, r *Reader) any {
+	ptr := typ.UnsafeNew()
+	dec.Decode(ptr, r)
 	if r.Error != nil {
 		return nil
 	}
-	obj := rTyp.UnsafeIndirect(rPtr)
+
+	obj := typ.UnsafeIndirect(ptr)
 	if reflect2.IsNil(obj) {
 		return nil
 	}
 
 	// Generic reader returns a different result from the
 	// codec in the case of a big.Rat. Handle this.
-	if rTyp.Type1() == ratType {
+	if typ.Type1() == ratType {
 		dec := obj.(big.Rat)
 		return &dec
 	}
-
 	return obj
 }
 
-func genericReceiver(schema Schema) (unsafe.Pointer, reflect2.Type, error) {
+func genericReceiver(schema Schema) (reflect2.Type, error) {
+	if schema.Type() == Ref {
+		schema = schema.(*RefSchema).Schema()
+	}
+
 	var ls LogicalSchema
 	lts, ok := schema.(LogicalTypeSchema)
 	if ok {
 		ls = lts.Logical()
 	}
 
-	name := string(schema.Type())
+	schemaName := string(schema.Type())
 	if ls != nil {
-		name += "." + string(ls.Type())
+		schemaName += "." + string(ls.Type())
 	}
 
 	switch schema.Type() {
 	case Boolean:
 		var v bool
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Int:
 		if ls != nil {
 			switch ls.Type() {
 			case Date:
 				var v time.Time
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 
 			case TimeMillis:
 				var v time.Duration
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			}
 		}
 		var v int
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Long:
 		if ls != nil {
 			switch ls.Type() {
 			case TimeMicros:
 				var v time.Duration
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			case TimestampMillis:
 				var v time.Time
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			case TimestampMicros:
 				var v time.Time
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			case LocalTimestampMillis:
 				var v time.Time
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			case LocalTimestampMicros:
 				var v time.Time
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			}
 		}
 		var v int64
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Float:
 		var v float32
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Double:
 		var v float64
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case String:
 		var v string
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Bytes:
 		if ls != nil && ls.Type() == Decimal {
 			var v *big.Rat
-			return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+			return reflect2.TypeOf(v), nil
 		}
 		var v []byte
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Record:
 		var v map[string]any
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
-	case Ref:
-		return genericReceiver(schema.(*RefSchema).Schema())
+		return reflect2.TypeOf(v), nil
 	case Enum:
 		var v string
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Array:
 		v := make([]any, 0)
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Map:
 		var v map[string]any
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Union:
 		var v map[string]any
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	case Fixed:
 		fixed := schema.(*FixedSchema)
 		ls := fixed.Logical()
@@ -126,15 +123,16 @@ func genericReceiver(schema Schema) (unsafe.Pointer, reflect2.Type, error) {
 			switch ls.Type() {
 			case Duration:
 				var v LogicalDuration
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			case Decimal:
 				var v big.Rat
-				return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+				return reflect2.TypeOf(v), nil
 			}
 		}
 		v := byteSliceToArray(make([]byte, fixed.Size()), fixed.Size())
-		return unsafe.Pointer(&v), reflect2.TypeOf(v), nil
+		return reflect2.TypeOf(v), nil
 	default:
-		return nil, nil, fmt.Errorf("dynamic receiver not found for schema: %v", name)
+		// This should not be possible.
+		return nil, errors.New("dynamic receiver not found for schema " + schemaName)
 	}
 }

--- a/codec_native.go
+++ b/codec_native.go
@@ -418,9 +418,7 @@ func (c *float64ConvCodec) Decode(ptr unsafe.Pointer, r *Reader) {
 	*((*float64)(ptr)) = c.convert(r)
 }
 
-type stringCodec struct {
-	convert func(*Reader) string
-}
+type stringCodec struct{}
 
 func (c *stringCodec) Decode(ptr unsafe.Pointer, r *Reader) {
 	*((*string)(ptr)) = r.ReadString()

--- a/converter.go
+++ b/converter.go
@@ -1,17 +1,9 @@
 package avro
 
-import (
-	"unsafe"
-
-	"github.com/modern-go/reflect2"
-)
-
 func createLongConverter(typ Type) func(*Reader) int64 {
 	switch typ {
 	case Int:
 		return func(r *Reader) int64 { return int64(r.ReadInt()) }
-	case Long:
-		return func(r *Reader) int64 { return r.ReadLong() }
 	default:
 		return nil
 	}
@@ -23,8 +15,6 @@ func createFloatConverter(typ Type) func(*Reader) float32 {
 		return func(r *Reader) float32 { return float32(r.ReadInt()) }
 	case Long:
 		return func(r *Reader) float32 { return float32(r.ReadLong()) }
-	case Float:
-		return func(r *Reader) float32 { return r.ReadFloat() }
 	default:
 		return nil
 	}
@@ -38,38 +28,6 @@ func createDoubleConverter(typ Type) func(*Reader) float64 {
 		return func(r *Reader) float64 { return float64(r.ReadLong()) }
 	case Float:
 		return func(r *Reader) float64 { return float64(r.ReadFloat()) }
-	case Double:
-		return func(r *Reader) float64 { return r.ReadDouble() }
-	default:
-		return nil
-	}
-}
-
-func createStringConverter(typ Type) func(*Reader) string {
-	switch typ {
-	case Bytes:
-		return func(r *Reader) string {
-			b := r.ReadBytes()
-			if len(b) == 0 {
-				return ""
-			}
-			return *(*string)(unsafe.Pointer(&b))
-		}
-	case String:
-		return func(r *Reader) string { return r.ReadString() }
-	default:
-		return nil
-	}
-}
-
-func createBytesConverter(typ Type) func(*Reader) []byte {
-	switch typ {
-	case String:
-		return func(r *Reader) []byte {
-			return reflect2.UnsafeCastString(r.ReadString())
-		}
-	case Bytes:
-		return func(r *Reader) []byte { return r.ReadBytes() }
 	default:
 		return nil
 	}

--- a/converter.go
+++ b/converter.go
@@ -1,73 +1,51 @@
 package avro
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/modern-go/reflect2"
 )
 
-type converter struct {
-	toLong   func(*Reader) int64
-	toFloat  func(*Reader) float32
-	toDouble func(*Reader) float64
-	toString func(*Reader) string
-	toBytes  func(*Reader) []byte
-}
-
-// resolveConverter returns a set of converter functions based on the actual type.
-// Depending on the actual type value, some converter functions may be nil;
-// thus, the downstream caller must first check the converter function value.
-func resolveConverter(typ Type) converter {
-	cv := converter{}
-	cv.toLong, _ = createLongConverter(typ)
-	cv.toFloat, _ = createFloatConverter(typ)
-	cv.toDouble, _ = createDoubleConverter(typ)
-	cv.toString, _ = createStringConverter(typ)
-	cv.toBytes, _ = createBytesConverter(typ)
-	return cv
-}
-
-func createLongConverter(typ Type) (func(*Reader) int64, error) {
+func createLongConverter(typ Type) func(*Reader) int64 {
 	switch typ {
 	case Int:
-		return func(r *Reader) int64 { return int64(r.ReadInt()) }, nil
+		return func(r *Reader) int64 { return int64(r.ReadInt()) }
 	case Long:
-		return func(r *Reader) int64 { return r.ReadLong() }, nil
+		return func(r *Reader) int64 { return r.ReadLong() }
 	default:
-		return nil, fmt.Errorf("cannot promote from %q to %q", typ, Long)
+		return nil
 	}
 }
 
-func createFloatConverter(typ Type) (func(*Reader) float32, error) {
+func createFloatConverter(typ Type) func(*Reader) float32 {
 	switch typ {
 	case Int:
-		return func(r *Reader) float32 { return float32(r.ReadInt()) }, nil
+		return func(r *Reader) float32 { return float32(r.ReadInt()) }
 	case Long:
-		return func(r *Reader) float32 { return float32(r.ReadLong()) }, nil
+		return func(r *Reader) float32 { return float32(r.ReadLong()) }
 	case Float:
-		return func(r *Reader) float32 { return r.ReadFloat() }, nil
+		return func(r *Reader) float32 { return r.ReadFloat() }
 	default:
-		return nil, fmt.Errorf("cannot promote from %q to %q", typ, Long)
+		return nil
 	}
 }
 
-func createDoubleConverter(typ Type) (func(*Reader) float64, error) {
+func createDoubleConverter(typ Type) func(*Reader) float64 {
 	switch typ {
 	case Int:
-		return func(r *Reader) float64 { return float64(r.ReadInt()) }, nil
+		return func(r *Reader) float64 { return float64(r.ReadInt()) }
 	case Long:
-		return func(r *Reader) float64 { return float64(r.ReadLong()) }, nil
+		return func(r *Reader) float64 { return float64(r.ReadLong()) }
 	case Float:
-		return func(r *Reader) float64 { return float64(r.ReadFloat()) }, nil
+		return func(r *Reader) float64 { return float64(r.ReadFloat()) }
 	case Double:
-		return func(r *Reader) float64 { return r.ReadDouble() }, nil
+		return func(r *Reader) float64 { return r.ReadDouble() }
 	default:
-		return nil, fmt.Errorf("cannot promote from %q to %q", typ, Long)
+		return nil
 	}
 }
 
-func createStringConverter(typ Type) (func(*Reader) string, error) {
+func createStringConverter(typ Type) func(*Reader) string {
 	switch typ {
 	case Bytes:
 		return func(r *Reader) string {
@@ -76,23 +54,23 @@ func createStringConverter(typ Type) (func(*Reader) string, error) {
 				return ""
 			}
 			return *(*string)(unsafe.Pointer(&b))
-		}, nil
+		}
 	case String:
-		return func(r *Reader) string { return r.ReadString() }, nil
+		return func(r *Reader) string { return r.ReadString() }
 	default:
-		return nil, fmt.Errorf("cannot promote from %q to %q", typ, Long)
+		return nil
 	}
 }
 
-func createBytesConverter(typ Type) (func(*Reader) []byte, error) {
+func createBytesConverter(typ Type) func(*Reader) []byte {
 	switch typ {
 	case String:
 		return func(r *Reader) []byte {
 			return reflect2.UnsafeCastString(r.ReadString())
-		}, nil
+		}
 	case Bytes:
-		return func(r *Reader) []byte { return r.ReadBytes() }, nil
+		return func(r *Reader) []byte { return r.ReadBytes() }
 	default:
-		return nil, fmt.Errorf("cannot promote from %q to %q", typ, Long)
+		return nil
 	}
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -6,106 +6,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestConverter(t *testing.T) {
+func TestLongConverter(t *testing.T) {
 	tests := []struct {
-		data         []byte
-		want         any
-		typ, wantTyp Type
-		wantErr      require.ErrorAssertionFunc
+		data []byte
+		typ  Type
+		want int64
 	}{
 		{
-			data:    []byte{0xE2, 0xA2, 0xF3, 0xAD, 0x07},
-			want:    int64(987654321),
-			typ:     Int,
-			wantTyp: Long,
-			wantErr: require.NoError,
+			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0x07},
+			typ:  Int,
+			want: 987654321,
 		},
 		{
-			data:    []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
-			want:    int64(9223372036854775807),
-			typ:     Long,
-			wantTyp: Long,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0xE2, 0xA2, 0xF3, 0xAD, 0x07},
-			want:    float32(987654321),
-			typ:     Int,
-			wantTyp: Float,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
-			want:    float32(9223372036854775807),
-			typ:     Long,
-			wantTyp: Float,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0x62, 0x20, 0x71, 0x49},
-			want:    float32(987654.124),
-			typ:     Float,
-			wantTyp: Float,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0xE2, 0xA2, 0xF3, 0xAD, 0x07},
-			want:    float64(987654321),
-			typ:     Int,
-			wantTyp: Double,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
-			want:    float64(9223372036854775807),
-			typ:     Long,
-			wantTyp: Double,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0x62, 0x20, 0x71, 0x49},
-			want:    float64(float32(987654.124)),
-			typ:     Float,
-			wantTyp: Double,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0xB6, 0xF3, 0x7D, 0x54, 0x34, 0x6F, 0x9D, 0xC1},
-			want:    float64(-123456789.123),
-			typ:     Double,
-			wantTyp: Double,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0x08, 0xEC, 0xAB, 0x44, 0x00},
-			want:    string([]byte{0xEC, 0xAB, 0x44, 0x00}),
-			typ:     Bytes,
-			wantTyp: String,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0x28, 0x6F, 0x70, 0x70, 0x61, 0x6E, 0x20, 0x67, 0x61, 0x6E, 0x67, 0x6E, 0x61, 0x6D, 0x20, 0x73, 0x74, 0x79, 0x6C, 0x65, 0x21},
-			want:    "oppan gangnam style!",
-			typ:     String,
-			wantTyp: String,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0x36, 0xD1, 0x87, 0xD0, 0xB5, 0x2D, 0xD1, 0x82, 0xD0, 0xBE, 0x20, 0xD0, 0xBF, 0xD0, 0xBE, 0x20, 0xD1, 0x80, 0xD1, 0x83, 0xD1, 0x81, 0xD1, 0x81, 0xD0, 0xBA, 0xD0, 0xB8},
-			want:    []byte("че-то по русски"),
-			typ:     String,
-			wantTyp: Bytes,
-			wantErr: require.NoError,
-		},
-		{
-			data:    []byte{0x0C, 0xAC, 0xDC, 0x01, 0x00, 0x10, 0x0F},
-			want:    []byte{0xAC, 0xDC, 0x01, 0x00, 0x10, 0x0F},
-			typ:     Bytes,
-			wantTyp: Bytes,
-			wantErr: require.NoError,
+			data: []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
+			typ:  Long,
+			want: 9223372036854775807,
 		},
 	}
 
@@ -113,24 +30,144 @@ func TestConverter(t *testing.T) {
 		test := test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			r := NewReader(bytes.NewReader(test.data), 10)
-			conv := resolveConverter(test.typ)
 
-			var got any
-			switch test.wantTyp {
-			case Long:
-				got = conv.toLong(r)
-			case Float:
-				got = conv.toFloat(r)
-			case Double:
-				got = conv.toDouble(r)
-			case String:
-				got = conv.toString(r)
-			case Bytes:
-				got = conv.toBytes(r)
-			default:
-			}
+			got := createLongConverter(test.typ)(r)
 
-			test.wantErr(t, r.Error)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestFloatConverter(t *testing.T) {
+	tests := []struct {
+		data []byte
+		typ  Type
+		want float32
+	}{
+		{
+			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0x07},
+			typ:  Int,
+			want: 987654321,
+		},
+		{
+			data: []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
+			typ:  Long,
+			want: 9223372036854775807,
+		},
+		{
+			data: []byte{0x62, 0x20, 0x71, 0x49},
+			typ:  Float,
+			want: 987654.124,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			r := NewReader(bytes.NewReader(test.data), 10)
+
+			got := createFloatConverter(test.typ)(r)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestDoubleConverter(t *testing.T) {
+	tests := []struct {
+		data []byte
+		typ  Type
+		want float64
+	}{
+		{
+			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0x07},
+			typ:  Int,
+			want: 987654321,
+		},
+		{
+			data: []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
+			typ:  Long,
+			want: 9223372036854775807,
+		},
+		{
+			data: []byte{0x62, 0x20, 0x71, 0x49},
+			typ:  Float,
+			want: float64(float32(987654.124)),
+		},
+		{
+			data: []byte{0xB6, 0xF3, 0x7D, 0x54, 0x34, 0x6F, 0x9D, 0xC1},
+			typ:  Double,
+			want: -123456789.123,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			r := NewReader(bytes.NewReader(test.data), 10)
+
+			got := createDoubleConverter(test.typ)(r)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestStringConverter(t *testing.T) {
+	tests := []struct {
+		data []byte
+		typ  Type
+		want string
+	}{
+		{
+			data: []byte{0x08, 0xEC, 0xAB, 0x44, 0x00},
+			typ:  Bytes,
+			want: string([]byte{0xEC, 0xAB, 0x44, 0x00}),
+		},
+		{
+			data: []byte{0x28, 0x6F, 0x70, 0x70, 0x61, 0x6E, 0x20, 0x67, 0x61, 0x6E, 0x67, 0x6E, 0x61, 0x6D, 0x20, 0x73, 0x74, 0x79, 0x6C, 0x65, 0x21},
+			typ:  String,
+			want: "oppan gangnam style!",
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			r := NewReader(bytes.NewReader(test.data), 10)
+
+			got := createStringConverter(test.typ)(r)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestBytesConverter(t *testing.T) {
+	tests := []struct {
+		data []byte
+		typ  Type
+		want []byte
+	}{
+		{
+			data: []byte{0x36, 0xd1, 0x87, 0xD0, 0xB5, 0x2D, 0xD1, 0x82, 0xD0, 0xBE, 0x20, 0xD0, 0xBF, 0xD0, 0xBE, 0x20, 0xD1, 0x80, 0xD1, 0x83, 0xD1, 0x81, 0xD1, 0x81, 0xD0, 0xBA, 0xD0, 0xB8},
+			typ:  String,
+			want: []byte("че-то по русски"),
+		},
+		{
+			data: []byte{0x0c, 0xac, 0xdc, 0x01, 0x00, 0x10, 0x0f},
+			typ:  Bytes,
+			want: []byte{0xac, 0xdc, 0x01, 0x00, 0x10, 0x0f},
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			r := NewReader(bytes.NewReader(test.data), 10)
+
+			got := createBytesConverter(test.typ)(r)
+
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/converter_test.go
+++ b/converter_test.go
@@ -19,11 +19,6 @@ func TestLongConverter(t *testing.T) {
 			typ:  Int,
 			want: 987654321,
 		},
-		{
-			data: []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
-			typ:  Long,
-			want: 9223372036854775807,
-		},
 	}
 
 	for i, test := range tests {
@@ -53,11 +48,6 @@ func TestFloatConverter(t *testing.T) {
 			data: []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
 			typ:  Long,
 			want: 9223372036854775807,
-		},
-		{
-			data: []byte{0x62, 0x20, 0x71, 0x49},
-			typ:  Float,
-			want: 987654.124,
 		},
 	}
 
@@ -94,11 +84,6 @@ func TestDoubleConverter(t *testing.T) {
 			typ:  Float,
 			want: float64(float32(987654.124)),
 		},
-		{
-			data: []byte{0xB6, 0xF3, 0x7D, 0x54, 0x34, 0x6F, 0x9D, 0xC1},
-			typ:  Double,
-			want: -123456789.123,
-		},
 	}
 
 	for i, test := range tests {
@@ -107,66 +92,6 @@ func TestDoubleConverter(t *testing.T) {
 			r := NewReader(bytes.NewReader(test.data), 10)
 
 			got := createDoubleConverter(test.typ)(r)
-
-			assert.Equal(t, test.want, got)
-		})
-	}
-}
-
-func TestStringConverter(t *testing.T) {
-	tests := []struct {
-		data []byte
-		typ  Type
-		want string
-	}{
-		{
-			data: []byte{0x08, 0xEC, 0xAB, 0x44, 0x00},
-			typ:  Bytes,
-			want: string([]byte{0xEC, 0xAB, 0x44, 0x00}),
-		},
-		{
-			data: []byte{0x28, 0x6F, 0x70, 0x70, 0x61, 0x6E, 0x20, 0x67, 0x61, 0x6E, 0x67, 0x6E, 0x61, 0x6D, 0x20, 0x73, 0x74, 0x79, 0x6C, 0x65, 0x21},
-			typ:  String,
-			want: "oppan gangnam style!",
-		},
-	}
-
-	for i, test := range tests {
-		test := test
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			r := NewReader(bytes.NewReader(test.data), 10)
-
-			got := createStringConverter(test.typ)(r)
-
-			assert.Equal(t, test.want, got)
-		})
-	}
-}
-
-func TestBytesConverter(t *testing.T) {
-	tests := []struct {
-		data []byte
-		typ  Type
-		want []byte
-	}{
-		{
-			data: []byte{0x36, 0xd1, 0x87, 0xD0, 0xB5, 0x2D, 0xD1, 0x82, 0xD0, 0xBE, 0x20, 0xD0, 0xBF, 0xD0, 0xBE, 0x20, 0xD1, 0x80, 0xD1, 0x83, 0xD1, 0x81, 0xD1, 0x81, 0xD0, 0xBA, 0xD0, 0xB8},
-			typ:  String,
-			want: []byte("че-то по русски"),
-		},
-		{
-			data: []byte{0x0c, 0xac, 0xdc, 0x01, 0x00, 0x10, 0x0f},
-			typ:  Bytes,
-			want: []byte{0xac, 0xdc, 0x01, 0x00, 0x10, 0x0f},
-		},
-	}
-
-	for i, test := range tests {
-		test := test
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			r := NewReader(bytes.NewReader(test.data), 10)
-
-			got := createBytesConverter(test.typ)(r)
 
 			assert.Equal(t, test.want, got)
 		})


### PR DESCRIPTION
This PR optimises the generic decode.

The benchmarked change is as follows:
```
name                      old time/op    new time/op    delta
SuperheroDecode-8            265ns ± 1%     254ns ± 2%   -4.10%  (p=0.000 n=10+10)
SuperheroEncode-8            201ns ± 1%     201ns ± 1%     ~     (p=0.946 n=9+9)
PartialSuperheroDecode-8     119ns ± 1%     118ns ± 0%   -0.86%  (p=0.003 n=9+9)
SuperheroGenericDecode-8    23.8µs ± 1%     2.1µs ± 0%  -91.23%  (p=0.000 n=10+10)
SuperheroGenericEncode-8     255ns ± 3%     260ns ± 2%   +1.91%  (p=0.004 n=10+10)
SuperheroWriteFlush-8        165ns ± 1%     164ns ± 1%   -0.60%  (p=0.008 n=9+10)

name                      old alloc/op   new alloc/op   delta
SuperheroDecode-8            47.0B ± 0%     47.0B ± 0%     ~     (all equal)
SuperheroEncode-8             112B ± 0%      112B ± 0%     ~     (all equal)
PartialSuperheroDecode-8     9.00B ± 0%     9.00B ± 0%     ~     (all equal)
SuperheroGenericDecode-8    8.37kB ± 0%    2.04kB ± 0%  -75.65%  (p=0.000 n=10+10)
SuperheroGenericEncode-8     80.0B ± 0%     80.0B ± 0%     ~     (all equal)
SuperheroWriteFlush-8        0.00B          0.00B          ~     (all equal)

name                      old allocs/op  new allocs/op  delta
SuperheroDecode-8             0.00           0.00          ~     (all equal)
SuperheroEncode-8             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
PartialSuperheroDecode-8      0.00           0.00          ~     (all equal)
SuperheroGenericDecode-8       303 ± 0%        60 ± 0%  -80.20%  (p=0.000 n=10+10)
SuperheroGenericEncode-8      3.00 ± 0%      3.00 ± 0%     ~     (all equal)
SuperheroWriteFlush-8         0.00           0.00          ~     (all equal)
```

Fixes #347