### PR TITLE
fix: schema compatibility fingerprint

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -34,8 +34,7 @@ type ValEncoder interface {
 
 // ReadVal parses Avro value and stores the result in the value pointed to by obj.
 func (r *Reader) ReadVal(schema Schema, obj any) {
-	key := cacheFingerprintOf(schema)
-	decoder := r.cfg.getDecoderFromCache(key, reflect2.RTypeOf(obj))
+	decoder := r.cfg.getDecoderFromCache(schema.CacheFingerprint(), reflect2.RTypeOf(obj))
 	if decoder == nil {
 		typ := reflect2.TypeOf(obj)
 		if typ.Kind() != reflect.Ptr {
@@ -66,15 +65,14 @@ func (w *Writer) WriteVal(schema Schema, val any) {
 
 func (c *frozenConfig) DecoderOf(schema Schema, typ reflect2.Type) ValDecoder {
 	rtype := typ.RType()
-	key := cacheFingerprintOf(schema)
-	decoder := c.getDecoderFromCache(key, rtype)
+	decoder := c.getDecoderFromCache(schema.CacheFingerprint(), rtype)
 	if decoder != nil {
 		return decoder
 	}
 
 	ptrType := typ.(*reflect2.UnsafePtrType)
 	decoder = decoderOfType(c, schema, ptrType.Elem())
-	c.addDecoderToCache(key, rtype, decoder)
+	c.addDecoderToCache(schema.CacheFingerprint(), rtype, decoder)
 	return decoder
 }
 

--- a/codec_native.go
+++ b/codec_native.go
@@ -12,7 +12,7 @@ import (
 
 //nolint:maintidx // Splitting this would not make it simpler.
 func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecoder {
-	isConv := schema.actual != ""
+	resolved := schema.encodedType != ""
 	switch typ.Kind() {
 	case reflect.Bool:
 		if schema.Type() != Boolean {
@@ -60,8 +60,8 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 		if schema.Type() != Long {
 			break
 		}
-		if isConv {
-			return &longConvCodec[uint32]{convert: createLongConverter(schema.actual)}
+		if resolved {
+			return &longConvCodec[uint32]{convert: createLongConverter(schema.encodedType)}
 		}
 		return &longCodec[uint32]{}
 
@@ -74,12 +74,12 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 
 		case st == Long && lt == TimeMicros: // time.Duration
 			return &timeMicrosCodec{
-				convert: createLongConverter(schema.actual),
+				convert: createLongConverter(schema.encodedType),
 			}
 
 		case st == Long:
-			if isConv {
-				return &longConvCodec[int64]{convert: createLongConverter(schema.actual)}
+			if resolved {
+				return &longConvCodec[int64]{convert: createLongConverter(schema.encodedType)}
 			}
 			return &longCodec[int64]{}
 
@@ -91,8 +91,8 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 		if schema.Type() != Float {
 			break
 		}
-		if isConv {
-			return &float32ConvCodec{convert: createFloatConverter(schema.actual)}
+		if resolved {
+			return &float32ConvCodec{convert: createFloatConverter(schema.encodedType)}
 		}
 		return &float32Codec{}
 
@@ -100,8 +100,8 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 		if schema.Type() != Double {
 			break
 		}
-		if isConv {
-			return &float64ConvCodec{convert: createDoubleConverter(schema.actual)}
+		if resolved {
+			return &float64ConvCodec{convert: createDoubleConverter(schema.encodedType)}
 		}
 		return &float64Codec{}
 
@@ -127,21 +127,21 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 			return &dateCodec{}
 		case isTime && st == Long && lt == TimestampMillis:
 			return &timestampMillisCodec{
-				convert: createLongConverter(schema.actual),
+				convert: createLongConverter(schema.encodedType),
 			}
 		case isTime && st == Long && lt == TimestampMicros:
 			return &timestampMicrosCodec{
-				convert: createLongConverter(schema.actual),
+				convert: createLongConverter(schema.encodedType),
 			}
 		case isTime && st == Long && lt == LocalTimestampMillis:
 			return &timestampMillisCodec{
 				local:   true,
-				convert: createLongConverter(schema.actual),
+				convert: createLongConverter(schema.encodedType),
 			}
 		case isTime && st == Long && lt == LocalTimestampMicros:
 			return &timestampMicrosCodec{
 				local:   true,
-				convert: createLongConverter(schema.actual),
+				convert: createLongConverter(schema.encodedType),
 			}
 		case typ.Type1().ConvertibleTo(ratType) && st == Bytes && lt == Decimal:
 			dec := ls.(*DecimalLogicalSchema)

--- a/schema.go
+++ b/schema.go
@@ -434,9 +434,9 @@ func withWriterFingerprint(fp [32]byte) SchemaOption {
 	}
 }
 
-func withWriterFingerprintIfResolved(fp [32]byte, isConv bool) SchemaOption {
+func withWriterFingerprintIfResolved(fp [32]byte, resolved bool) SchemaOption {
 	return func(opts *schemaConfig) {
-		if isConv {
+		if resolved {
 			opts.wfp = &fp
 		}
 	}

--- a/schema_compatibility_test.go
+++ b/schema_compatibility_test.go
@@ -577,7 +577,9 @@ func TestSchemaCompatibility_Resolve(t *testing.T) {
 			// decoder cache must be aware of fields defaults.
 			name: "Record Writer Field Missing With Record Default 2",
 			reader: `{
-						"type":"record", "name":"test", "namespace": "org.hamba.avro",
+						"type":"record", 
+						"name":"test", 
+						"namespace": "org.hamba.avro",
 						"fields":[
 							{"name": "a", "type": "int"},
 							{

--- a/schema_internal_test.go
+++ b/schema_internal_test.go
@@ -566,66 +566,6 @@ func TestSchema_FieldEncodeDefault(t *testing.T) {
 	assert.Equal(t, []byte("foo"), def)
 }
 
-// func TestSchema_CacheFingerprint(t *testing.T) {
-// 	t.Run("invalid", func(t *testing.T) {
-// 		cacheFingerprint := cacheFingerprinter{}
-// 		assert.Panics(t, func() {
-// 			cacheFingerprint.fingerprint([]any{func() {}})
-// 		})
-// 	})
-//
-// 	t.Run("promoted", func(t *testing.T) {
-// 		schema := NewPrimitiveSchema(Long, nil)
-// 		assert.Equal(t, schema.Fingerprint(), schema.CacheFingerprint())
-//
-// 		schema = NewPrimitiveSchema(Long, nil)
-// 		schema.encodedType = Int
-// 		assert.NotEqual(t, schema.Fingerprint(), schema.CacheFingerprint())
-// 	})
-//
-// 	t.Run("enum", func(t *testing.T) {
-// 		schema1 := MustParse(`{
-// 			"type": "enum",
-// 			"name": "test.enum",
-// 			"symbols": ["foo"]
-// 		}`).(*EnumSchema)
-//
-// 		schema2 := MustParse(`{
-// 			"type": "enum",
-// 			"name": "test.enum",
-// 			"symbols": ["foo"],
-// 			"default": "foo"
-// 			}`).(*EnumSchema)
-// 		schema2.encodedSymbols = []string{"boo"}
-//
-// 		assert.Equal(t, schema1.Fingerprint(), schema1.CacheFingerprint())
-// 		assert.NotEqual(t, schema1.CacheFingerprint(), schema2.CacheFingerprint())
-// 	})
-//
-// 	t.Run("record", func(t *testing.T) {
-// 		schema1 := MustParse(`{
-// 			"type": "record",
-// 			"name": "test",
-// 			"fields" : [
-// 				{"name": "a", "type": "string"},
-// 				{"name": "b", "type": "boolean"}
-// 			]
-// 		}`).(*RecordSchema)
-//
-// 		schema2 := MustParse(`{
-// 			"type": "record",
-// 			"name": "test2",
-// 			"fields" : [
-// 				{"name": "a", "type": "string", "default": "bar"},
-// 				{"name": "b", "type": "boolean", "default": false}
-// 			]
-// 		}`).(*RecordSchema)
-//
-// 		assert.Equal(t, schema1.Fingerprint(), schema1.CacheFingerprint())
-// 		assert.NotEqual(t, schema1.CacheFingerprint(), schema2.CacheFingerprint())
-// 	})
-// }
-
 func TestEnumSchema_GetSymbol(t *testing.T) {
 	tests := []struct {
 		schemaFn func() *EnumSchema


### PR DESCRIPTION
When a schema contains a compatibility change anywhere in its tree, the entire schema should show the change in its fingerprint. To make this simpler, the writer fingerprint is carried in the schema, to show this change. There is an edge case in records that the exact defaults must be accounted for in the cached fingerprint.

This has the benefit of slightly optimising the planning phase.
```
name                      old time/op    new time/op    delta
SuperheroDecode-8            232ns ± 1%     229ns ± 1%  -1.27%  (p=0.000 n=10+10)
SuperheroEncode-8            198ns ± 0%     199ns ± 1%  +0.68%  (p=0.000 n=10+10)
PartialSuperheroDecode-8     106ns ± 0%      97ns ± 1%  -8.05%  (p=0.000 n=8+9)
SuperheroGenericDecode-8    2.17µs ± 0%    2.17µs ± 0%    ~     (p=0.376 n=8+9)
SuperheroGenericEncode-8     251ns ± 2%     247ns ± 0%  -1.67%  (p=0.000 n=10+8)
SuperheroWriteFlush-8        162ns ± 1%     162ns ± 2%    ~     (p=0.675 n=9+10)

name                      old alloc/op   new alloc/op   delta
SuperheroDecode-8            47.0B ± 0%     47.0B ± 0%    ~     (all equal)
SuperheroEncode-8             112B ± 0%      112B ± 0%    ~     (all equal)
PartialSuperheroDecode-8     9.00B ± 0%     9.00B ± 0%    ~     (all equal)
SuperheroGenericDecode-8    2.04kB ± 0%    2.04kB ± 0%    ~     (all equal)
SuperheroGenericEncode-8     80.0B ± 0%     80.0B ± 0%    ~     (all equal)
SuperheroWriteFlush-8        0.00B          0.00B         ~     (all equal)

name                      old allocs/op  new allocs/op  delta
SuperheroDecode-8             0.00           0.00         ~     (all equal)
SuperheroEncode-8             1.00 ± 0%      1.00 ± 0%    ~     (all equal)
PartialSuperheroDecode-8      0.00           0.00         ~     (all equal)
SuperheroGenericDecode-8      60.0 ± 0%      60.0 ± 0%    ~     (all equal)
SuperheroGenericEncode-8      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
SuperheroWriteFlush-8         0.00           0.00         ~     (all equal)
```