### PR TITLE
Fix: Union reader schema resolution

### DIFF
--- a/schema_compatibility.go
+++ b/schema_compatibility.go
@@ -292,6 +292,11 @@ func (c *SchemaCompatibility) resolve(reader, writer Schema) (schema Schema, res
 	if writer.Type() != reader.Type() {
 		if reader.Type() == Union {
 			for _, schema := range reader.(*UnionSchema).Types() {
+				// Compatibility is not guaranteed for every Union reader schema.
+				// Therefore, we need to check compatibility in every iteration.
+				if err := c.compatible(schema, writer); err != nil {
+					continue
+				}
 				sch, _, err := c.resolve(schema, writer)
 				if err != nil {
 					continue


### PR DESCRIPTION
In the Union reader case, we check that the writer schema is compatible with at least one reader schema and resolve the composite schema against the first compatible found one.

We may pass through some incompatible schemas first; we need to explicitly check compatibility for each iteration by calling the `compatible` function (or `Resolve` instead of `resolve`).

The `compatible` function does cache its results, and the added calls will likely hit the cache, so I'm optimistic about the performance :) 