### PR TITLE
feat: support slices for nullable unions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ When a non-`nil` union value is encountered, a single key is en/decoded. The key
 type name, or scheam full name in the case of a named schema (enum, fixed or record).
 * ***T:** This is allowed in a "nullable" union. A nullable union is defined as a two schema union, 
 with one of the types being `null` (ie. `["null", "string"]` or `["string", "null"]`), in this case 
-a `*T` is allowed, with `T` matching the conversion table above.
+a `*T` is allowed, with `T` matching the conversion table above. In the case of a slice, the slice can be used
+directly.
 * **any:** An `interface` can be provided and the type or name resolved. Primitive types
 are pre-registered, but named types, maps and slices will need to be registered with the `Register` function. 
 In the case of arrays and maps the enclosed schema type or name is postfix to the type with a `:` separator, 

--- a/codec_record.go
+++ b/codec_record.go
@@ -184,7 +184,7 @@ func encoderOfStruct(cfg *frozenConfig, schema Schema, typ reflect2.Type) ValEnc
 				defaultType := reflect2.TypeOf(&def)
 				fields = append(fields, &structFieldEncoder{
 					defaultPtr: reflect2.PtrOf(&def),
-					encoder:    encoderOfPtrUnion(cfg, field.Type(), defaultType),
+					encoder:    encoderOfNullableUnion(cfg, field.Type(), defaultType),
 				})
 				continue
 			}

--- a/encoder_union_test.go
+++ b/encoder_union_test.go
@@ -256,6 +256,36 @@ func TestEncoder_UnionPtrNotNullable(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEncoder_UnionNullableSlice(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["null", "bytes"]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	b := []byte("foo")
+	err = enc.Encode(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x06, 0x66, 0x6F, 0x6F}, buf.Bytes())
+}
+
+func TestEncoder_UnionNullableSliceNull(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["null", "bytes"]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var b []byte
+	err = enc.Encode(b)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x00}, buf.Bytes())
+}
+
 func TestEncoder_UnionInterface(t *testing.T) {
 	defer ConfigTeardown()
 


### PR DESCRIPTION
This PR adds support for slices directly in nullable unions.

Maps are more complex and will be looked at separately. 

Fixes #371