### PR TITLE
Check for max allocation

### DIFF
--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -78,3 +78,16 @@ func TestDecoder_ArraySliceItemError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestDecoder_ArrayMaxAllocationError(t *testing.T) {
+	defer ConfigTeardown()
+	data := []byte{0x2, 0x0, 0xe9, 0xe9, 0xe9, 0xe9, 0xe9, 0xe9, 0xe9, 0xe9, 0x0}
+	schema := `{"type":"array", "items": { "type": "boolean" }}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got []bool
+	err = dec.Decode(&got)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Issue: https://github.com/hamba/avro/issues/373

This PR checks to see if the `size` to allocate the array exceeds the max allocation size. This prevents getting `panic: runtime: allocation size out of range` when decoding arrays with an invalid size.

This is the code to reproduce the error before the fix:
```
package main

import "github.com/hamba/avro/v2"

func main() {
	rawSchema := []byte("{\"items\":{\"type\":\"boolean\"},\"type\":\"array\"}")

	schema, _ := avro.ParseBytes(rawSchema)

	data := []byte("\x02\x00\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\x00")
	var container any
	avro.Unmarshal(schema, data, &container)
}
```

This is the [line of code](https://github.com/hamba/avro/blob/7a2eb5fdc5a4c5abf9712c0e12c3806691f866d5/codec_array.go#L54) that leads to the error. The size is 29787588086545014 while the maxAlloc size is 281474976710656 (const maxAlloc untyped int = (1 << heapAddrBits) - (1-_64bit)*1)