### PR TITLE
feat: add max slice alloc size config

### DIFF
--- a/codec_array.go
+++ b/codec_array.go
@@ -39,10 +39,6 @@ type arrayDecoder struct {
 	decoder ValDecoder
 }
 
-// Max allocation size for an array due to the limit in number of bits in a heap address:
-// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
-var maxAllocSize = uint64(1 << 48)
-
 func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 	var size int
 	sliceType := d.typ
@@ -55,12 +51,8 @@ func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 
 		start := size
 		size += int(l)
-		if size > int(maxAllocSize) {
-			r.ReportError("decode array", "size exceeded max allocation size")
-			return
-		}
 
-		if max := r.cfg.getMaxSliceAllocSize(); max > 0 && size > max {
+		if size > r.cfg.getMaxSliceAllocSize() {
 			r.ReportError("decode array", "size is greater than `Config.MaxSliceAllocSize`")
 			return
 		}

--- a/codec_array.go
+++ b/codec_array.go
@@ -59,6 +59,12 @@ func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 			r.ReportError("decode array", "size exceeded max allocation size")
 			return
 		}
+
+		if max := r.cfg.getMaxSliceAllocSize(); max > 0 && size > max {
+			r.ReportError("decode array", "size is greater than `Config.MaxSliceAllocSize`")
+			return
+		}
+
 		sliceType.UnsafeGrow(ptr, size)
 
 		for i := start; i < size; i++ {

--- a/config.go
+++ b/config.go
@@ -12,8 +12,7 @@ const (
 	defaultMaxByteSliceSize = 1_048_576 // 1 MiB
 	// Max allocation size for an array due to the limit in number of bits in a heap address:
 	// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
-	maxAllocSize             = int(1 << 48)
-	defaultMaxSliceAllocSize = maxAllocSize
+	maxAllocSize = int(1 << 48)
 )
 
 // DefaultConfig is the default API.

--- a/config.go
+++ b/config.go
@@ -9,8 +9,11 @@ import (
 )
 
 const (
-	defaultMaxByteSliceSize  = 1_048_576 // 1 MiB
-	defaultMaxSliceAllocSize = -1
+	defaultMaxByteSliceSize = 1_048_576 // 1 MiB
+	// Max allocation size for an array due to the limit in number of bits in a heap address:
+	// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
+	maxAllocSize             = int(1 << 48)
+	defaultMaxSliceAllocSize = maxAllocSize
 )
 
 // DefaultConfig is the default API.
@@ -274,10 +277,6 @@ func (c *frozenConfig) getMaxByteSliceSize() int {
 	}
 	return size
 }
-
-// Max allocation size for an array due to the limit in number of bits in a heap address:
-// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
-var maxAllocSize = int(1 << 48)
 
 func (c *frozenConfig) getMaxSliceAllocSize() int {
 	size := c.config.MaxSliceAllocSize

--- a/config.go
+++ b/config.go
@@ -53,8 +53,9 @@ type Config struct {
 	// If this size is exceeded, the Reader returns an error. This can be disabled by setting a negative number.
 	MaxByteSliceSize int
 
-	// MaxSliceAllocSize is the maximum size that the decoder will allocate, disabled by default.
-	// If this size is exceeded, the decoder returns an error. This can be disabled by setting a negative number.
+	// MaxSliceAllocSize is the maximum size that the decoder will allocate, set to the max heap
+	// allocation size by default.
+	// If this size is exceeded, the decoder returns an error.
 	MaxSliceAllocSize int
 }
 
@@ -274,10 +275,14 @@ func (c *frozenConfig) getMaxByteSliceSize() int {
 	return size
 }
 
+// Max allocation size for an array due to the limit in number of bits in a heap address:
+// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
+var maxAllocSize = int(1 << 48)
+
 func (c *frozenConfig) getMaxSliceAllocSize() int {
 	size := c.config.MaxSliceAllocSize
-	if size == 0 {
-		return defaultMaxSliceAllocSize
+	if size > maxAllocSize || size <= 0 {
+		return maxAllocSize
 	}
 	return size
 }

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 )
 
 const defaultMaxByteSliceSize = 1_048_576 // 1 MiB
+const defaultMaxSliceAllocSize = -1
 
 // DefaultConfig is the default API.
 var DefaultConfig = Config{}.Freeze()
@@ -49,6 +50,10 @@ type Config struct {
 	// MaxByteSliceSize is the maximum size of `bytes` or `string` types the Reader will create, defaulting to 1MiB.
 	// If this size is exceeded, the Reader returns an error. This can be disabled by setting a negative number.
 	MaxByteSliceSize int
+
+	// MaxSliceAllocSize is the maximum size that the decoder will allocate, disabled by default.
+	// If this size is exceeded, the decoder returns an error. This can be disabled by setting a negative number.
+	MaxSliceAllocSize int
 }
 
 // Freeze makes the configuration immutable.
@@ -263,6 +268,14 @@ func (c *frozenConfig) getMaxByteSliceSize() int {
 	size := c.config.MaxByteSliceSize
 	if size == 0 {
 		return defaultMaxByteSliceSize
+	}
+	return size
+}
+
+func (c *frozenConfig) getMaxSliceAllocSize() int {
+	size := c.config.MaxSliceAllocSize
+	if size == 0 {
+		return defaultMaxSliceAllocSize
 	}
 	return size
 }

--- a/config.go
+++ b/config.go
@@ -8,8 +8,10 @@ import (
 	"github.com/modern-go/reflect2"
 )
 
-const defaultMaxByteSliceSize = 1_048_576 // 1 MiB
-const defaultMaxSliceAllocSize = -1
+const (
+	defaultMaxByteSliceSize  = 1_048_576 // 1 MiB
+	defaultMaxSliceAllocSize = -1
+)
 
 // DefaultConfig is the default API.
 var DefaultConfig = Config{}.Freeze()

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -91,3 +91,18 @@ func TestDecoder_ArrayMaxAllocationError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestDecoder_ArrayExceedMaxSliceAllocationConfig(t *testing.T) {
+	avro.DefaultConfig = avro.Config{MaxSliceAllocSize: 5}.Freeze()
+
+	// 10 (long) gets encoded to 0x14
+	data := []byte{0x14}
+	schema := `{"type":"array", "items": { "type": "boolean" }}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got []bool
+	err = dec.Decode(&got)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
I introduced the `defaultMaxSliceAllocSize` config for security reasons, similar to `Config.MaxByteSliceSize` introduced in this [PR](https://github.com/brianshih1/avro/commit/b4a402f41cf44b6094b5131286830ba9bb1eb290).

I need a way to prevent the array decoder from consuming too much memory for my application, the `defaultMaxSliceAllocSize` is the limit for how much memory the `arrayDecoder` can allocate.

Let me know if you think I should just reuse `MaxByteSliceSize` instead of introducing a new config.