### PR TITLE
Add API to check if Decoder's Reader has reached EOF

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -49,7 +49,7 @@ func Unmarshal(schema Schema, data []byte, v any) error {
 	return DefaultConfig.Unmarshal(schema, data, v)
 }
 
-// Whether the decoder's reader has reached EOF.
-func (d *Decoder) IsEof() bool {
-	return d.r.Error == io.EOF
+// IsEOF returns Whether the decoder's reader has reached EOF.
+func (d *Decoder) IsEOF() bool {
+	return errors.Is(d.r.Error, io.EOF)
 }

--- a/decoder.go
+++ b/decoder.go
@@ -48,3 +48,8 @@ func (d *Decoder) Decode(obj any) error {
 func Unmarshal(schema Schema, data []byte, v any) error {
 	return DefaultConfig.Unmarshal(schema, data, v)
 }
+
+// Whether the decoder's reader has reached EOF.
+func (d *Decoder) IsEof() bool {
+	return d.r.Error == io.EOF
+}

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -117,6 +117,6 @@ func TestDecoder_ArrayEof(t *testing.T) {
 
 	var got []bool
 	err = dec.Decode(&got)
-	assert.True(t, dec.IsEof())
+	assert.True(t, dec.IsEOF())
 	assert.NoError(t, err)
 }

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -106,3 +106,17 @@ func TestDecoder_ArrayExceedMaxSliceAllocationConfig(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestDecoder_ArrayEof(t *testing.T) {
+
+	// 10 (long) gets encoded to 0x14
+	data := []byte{0x14}
+	schema := `{"type":"array", "items": { "type": "boolean" }}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var got []bool
+	err = dec.Decode(&got)
+	assert.True(t, dec.IsEof())
+	assert.NoError(t, err)
+}

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -93,6 +93,7 @@ func TestDecoder_ArrayMaxAllocationError(t *testing.T) {
 }
 
 func TestDecoder_ArrayExceedMaxSliceAllocationConfig(t *testing.T) {
+	defer ConfigTeardown()
 	avro.DefaultConfig = avro.Config{MaxSliceAllocSize: 5}.Freeze()
 
 	// 10 (long) gets encoded to 0x14
@@ -108,7 +109,6 @@ func TestDecoder_ArrayExceedMaxSliceAllocationConfig(t *testing.T) {
 }
 
 func TestDecoder_ArrayEof(t *testing.T) {
-
 	// 10 (long) gets encoded to 0x14
 	data := []byte{0x14}
 	schema := `{"type":"array", "items": { "type": "boolean" }}`

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -79,7 +79,7 @@ func TestDecoder_DecodeEOFDoesntReturnError(t *testing.T) {
 	err := dec.Decode(&i)
 
 	assert.NoError(t, err)
-	assert.True(t, dec.IsEof())
+	assert.True(t, dec.IsEOF())
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -79,6 +79,7 @@ func TestDecoder_DecodeEOFDoesntReturnError(t *testing.T) {
 	err := dec.Decode(&i)
 
 	assert.NoError(t, err)
+	assert.True(t, dec.IsEof())
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
[Issue](https://github.com/hamba/avro/issues/377)

It looks like the `Decoder` is swallowing `EOF` errors in [this line of code](https://github.com/hamba/avro/blob/b43fe48eef0167a038bc192051bce6fcfc8be56e/decoder.go#L39). Just curious, what is the reasoning behind that?

In the example below, I am trying to decode an `array of boolean` with an invalid data (contains an encoded `long` but no data for the boolean). I was expecting it to error out as we are dealing with invalid input but the `EOF` error is swallowed so the following test fails.

```
func TestDecoder_ArrayEof(t *testing.T) {
	// 10 (long) gets encoded to 0x14
	data := []byte{0x14}
	schema := `{"type":"array", "items": { "type": "boolean" }}`
	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
	require.NoError(t, err)

	var got []bool
	err = dec.Decode(&got)

	assert.Error(t, err)
}
```

My application needs to detect whether the decoder has reached `EOF` unexpectedly. So I added an `IsEof` method to the decoder. Let me know if this doesn't make sense!