### PR TITLE
fix: handle short read errors on arrays and maps

### DIFF
--- a/codec_array.go
+++ b/codec_array.go
@@ -62,8 +62,8 @@ func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 		for i := start; i < size; i++ {
 			elemPtr := sliceType.UnsafeGetIndex(ptr, i)
 			d.decoder.Decode(elemPtr, r)
-			if r.Error != nil && !errors.Is(r.Error, io.EOF) {
-				r.Error = fmt.Errorf("%s: %w", d.typ.String(), r.Error)
+			if r.Error != nil {
+				r.Error = fmt.Errorf("reading %s: %w", d.typ.String(), r.Error)
 				return
 			}
 		}

--- a/codec_map.go
+++ b/codec_map.go
@@ -72,6 +72,10 @@ func (d *mapDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 			keyPtr := reflect2.PtrOf(r.ReadString())
 			elemPtr := d.elemType.UnsafeNew()
 			d.decoder.Decode(elemPtr, r)
+			if r.Error != nil {
+				r.Error = fmt.Errorf("reading map[string]%s: %w", d.elemType.String(), r.Error)
+				return
+			}
 
 			d.mapType.UnsafeSetIndex(ptr, keyPtr, elemPtr)
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -1,7 +1,6 @@
 package avro
 
 import (
-	"errors"
 	"io"
 )
 
@@ -36,10 +35,10 @@ func (d *Decoder) Decode(obj any) error {
 
 	d.r.ReadVal(d.s, obj)
 
-	if errors.Is(d.r.Error, io.EOF) {
+	//nolint:errorlint // Only direct EOF errors should be discarded.
+	if d.r.Error == io.EOF {
 		return nil
 	}
-
 	return d.r.Error
 }
 

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -37,6 +37,19 @@ func TestDecoder_ArraySlice(t *testing.T) {
 	assert.Equal(t, []int{27, 28}, got)
 }
 
+func TestDecoder_ArraySliceShortRead(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x04}
+	schema := `{"type":"array", "items": "int"}`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got []int
+	err := dec.Decode(&got)
+
+	assert.Error(t, err)
+}
+
 func TestDecoder_ArraySliceOfStruct(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/decoder_map_test.go
+++ b/decoder_map_test.go
@@ -39,6 +39,19 @@ func TestDecoder_MapMap(t *testing.T) {
 	assert.Equal(t, map[string]string{"foo": "foo"}, got)
 }
 
+func TestDecoder_MapMapShortRead(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x02, 0x06, 0x66, 0x6F, 0x6F, 0x06, 0x06}
+	schema := `{"type":"map", "values": "string"}`
+	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
+
+	var got map[string]string
+	err := dec.Decode(&got)
+
+	assert.Error(t, err)
+}
+
 func TestDecoder_MapMapOfStruct(t *testing.T) {
 	defer ConfigTeardown()
 


### PR DESCRIPTION
This fixes an issues were short-reads on maps and arrays are not returned.

Fixes #377