### PR TITLE
ReadInt and ReadLong eof

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -174,6 +174,7 @@ func (r *Reader) ReadInt() int32 {
 		// We ran out of buffer and are not at the end of the int,
 		// Read more into the buffer.
 		if !r.loadMore() {
+			r.Error = fmt.Errorf("reading int %w", r.Error)
 			return 0
 		}
 	}
@@ -216,6 +217,7 @@ func (r *Reader) ReadLong() int64 {
 		// We ran out of buffer and are not at the end of the long,
 		// Read more into the buffer.
 		if !r.loadMore() {
+			r.Error = fmt.Errorf("reading long %w", r.Error)
 			return 0
 		}
 	}


### PR DESCRIPTION
My intuition is that if the reader tries to `ReadInt` or `ReadLong` and it encounters an `EOF` before the end of the int/long, then it should be an error. In that case, we should wrap the `EOF` error.

However, after this PR's change, two tests are failing: `TestDecoder_SkipRef` and `TestDecoder_DecodeEOFDoesntReturnError`.

```
func TestDecoder_DecodeEOFDoesntReturnError(t *testing.T) {
	defer ConfigTeardown()

	data := []byte{0xE2}
	schema := "int"
	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))

	var i int
	err := dec.Decode(&i)

	assert.NoError(t, err)
}
```

Is my assumption correct? And in that case what should we do with these tests?