### PR TITLE
fix: handle short read errors on string

### DIFF
--- a/decoder_native_test.go
+++ b/decoder_native_test.go
@@ -359,6 +359,20 @@ func TestDecoder_String(t *testing.T) {
 	assert.Equal(t, "foo", str)
 }
 
+func TestDecoder_StringEOF(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x08}
+	schema := "string"
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var str string
+	err = dec.Decode(&str)
+
+	require.Error(t, err)
+}
+
 func TestDecoder_StringInvalidSchema(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -68,7 +68,7 @@ func TestDecoder_DecodeNilPtr(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDecoder_DecodeEOFDoesntReturnError(t *testing.T) {
+func TestDecoder_DecodeEOF(t *testing.T) {
 	defer ConfigTeardown()
 
 	data := []byte{0xE2}
@@ -78,7 +78,7 @@ func TestDecoder_DecodeEOFDoesntReturnError(t *testing.T) {
 	var i int
 	err := dec.Decode(&i)
 
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -87,7 +87,7 @@ func TestUnmarshal(t *testing.T) {
 	schema := avro.MustParse("int")
 
 	var i int
-	err := avro.Unmarshal(schema, []byte{0xE2}, &i)
+	err := avro.Unmarshal(schema, []byte{0x13}, &i)
 
 	assert.NoError(t, err)
 }

--- a/reader.go
+++ b/reader.go
@@ -247,6 +247,10 @@ func (r *Reader) ReadBytes() []byte {
 // ReadString reads a String from the Reader.
 func (r *Reader) ReadString() string {
 	b := r.readBytes("string")
+	if r.Error != nil {
+		r.Error = fmt.Errorf("reading string: %w", r.Error)
+	}
+
 	if len(b) == 0 {
 		return ""
 	}

--- a/reader.go
+++ b/reader.go
@@ -139,6 +139,8 @@ func (r *Reader) ReadBool() bool {
 }
 
 // ReadInt reads an Int from the Reader.
+//
+//nolint:dupl // Not the same as ReadLong
 func (r *Reader) ReadInt() int32 {
 	if r.Error != nil {
 		return 0
@@ -182,6 +184,8 @@ func (r *Reader) ReadInt() int32 {
 }
 
 // ReadLong reads a Long from the Reader.
+//
+//nolint:dupl // Not the same as ReadInt
 func (r *Reader) ReadLong() int64 {
 	if r.Error != nil {
 		return 0

--- a/reader.go
+++ b/reader.go
@@ -117,6 +117,7 @@ func (r *Reader) Read(b []byte) {
 	for read < size {
 		if r.head == r.tail {
 			if !r.loadMore() {
+				r.Error = io.ErrUnexpectedEOF
 				return
 			}
 		}
@@ -174,6 +175,7 @@ func (r *Reader) ReadInt() int32 {
 		// We ran out of buffer and are not at the end of the int,
 		// Read more into the buffer.
 		if !r.loadMore() {
+			r.Error = io.ErrUnexpectedEOF
 			return 0
 		}
 	}
@@ -216,6 +218,7 @@ func (r *Reader) ReadLong() int64 {
 		// We ran out of buffer and are not at the end of the long,
 		// Read more into the buffer.
 		if !r.loadMore() {
+			r.Error = io.ErrUnexpectedEOF
 			return 0
 		}
 	}
@@ -247,9 +250,6 @@ func (r *Reader) ReadBytes() []byte {
 // ReadString reads a String from the Reader.
 func (r *Reader) ReadString() string {
 	b := r.readBytes("string")
-	if r.Error != nil {
-		r.Error = fmt.Errorf("reading string: %w", r.Error)
-	}
 
 	if len(b) == 0 {
 		return ""
@@ -288,6 +288,7 @@ func (r *Reader) readBytes(op string) []byte {
 	}
 
 	buf := make([]byte, size)
+
 	r.Read(buf)
 	return buf
 }


### PR DESCRIPTION
A string is encoded as a long followed by that many bytes of UTF-8 encoded character data. If there aren't that many bytes of encoded character data, then it is an error.

For example, `0x08` decodes to long(4). Decoding the bytes`[]byte{0x08}` to a string should result in an error.

This PR wraps the `EOF` error, similar to the [PR](https://github.com/hamba/avro/pull/379) to fix array/maps.