### PR TITLE
fix: reader returns errors on unexpected EOF

### DIFF
--- a/codec_skip_test.go
+++ b/codec_skip_test.go
@@ -194,7 +194,7 @@ func TestDecoder_SkipRecord(t *testing.T) {
 func TestDecoder_SkipRef(t *testing.T) {
 	defer ConfigTeardown()
 
-	data := []byte{0x02, 0x66, 0x06, 0x66, 0x6f, 0x6f}
+	data := []byte{0x02, 0x66, 0x06, 0x66, 0x6f, 0x6f, 0x02, 0x66}
 	schema := `{
 	"type": "record",
 	"name": "test",

--- a/decoder_native_test.go
+++ b/decoder_native_test.go
@@ -69,6 +69,20 @@ func TestDecoder_Int(t *testing.T) {
 	assert.Equal(t, 27, i)
 }
 
+func TestDecoder_IntShortRead(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0xe6}
+	schema := "int"
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var i int
+	err = dec.Decode(&i)
+
+	assert.Error(t, err)
+}
+
 func TestDecoder_IntInvalidSchema(t *testing.T) {
 	defer ConfigTeardown()
 
@@ -272,6 +286,20 @@ func TestDecoder_Int64(t *testing.T) {
 	assert.Equal(t, int64(27), i)
 }
 
+func TestDecoder_Int64ShortRead(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0xe6}
+	schema := "long"
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var i int64
+	err = dec.Decode(&i)
+
+	assert.Error(t, err)
+}
+
 func TestDecoder_Int64InvalidSchema(t *testing.T) {
 	defer ConfigTeardown()
 
@@ -359,6 +387,20 @@ func TestDecoder_String(t *testing.T) {
 	assert.Equal(t, "foo", str)
 }
 
+func TestDecoder_StringShortRead(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x08}
+	schema := "string"
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var str string
+	err = dec.Decode(&str)
+
+	require.Error(t, err)
+}
+
 func TestDecoder_StringInvalidSchema(t *testing.T) {
 	defer ConfigTeardown()
 
@@ -386,6 +428,20 @@ func TestDecoder_Bytes(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0xEC, 0xAB, 0x44, 0x00}, b)
+}
+
+func TestDecoder_BytesShortRead(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x08, 0xEC}
+	schema := "bytes"
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var b []byte
+	err = dec.Decode(&b)
+
+	assert.Error(t, err)
 }
 
 func TestDecoder_BytesInvalidSchema(t *testing.T) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -68,19 +68,6 @@ func TestDecoder_DecodeNilPtr(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDecoder_DecodeEOFDoesntReturnError(t *testing.T) {
-	defer ConfigTeardown()
-
-	data := []byte{0xE2}
-	schema := "int"
-	dec, _ := avro.NewDecoder(schema, bytes.NewReader(data))
-
-	var i int
-	err := dec.Decode(&i)
-
-	assert.NoError(t, err)
-}
-
 func TestUnmarshal(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -114,9 +114,16 @@ func (d *Decoder) Error() error {
 }
 
 func (d *Decoder) readBlock() int64 {
+	_ = d.reader.Peek()
+	if errors.Is(d.reader.Error, io.EOF) {
+		// There is no next block
+		return 0
+	}
+
 	count := d.reader.ReadLong()
 	size := d.reader.ReadLong()
 
+	// Read the blocks data
 	if count > 0 {
 		data := make([]byte, size)
 		d.reader.Read(data)
@@ -129,6 +136,7 @@ func (d *Decoder) readBlock() int64 {
 		d.resetReader.Reset(data)
 	}
 
+	// Read the sync.
 	var sync [16]byte
 	d.reader.Read(sync[:])
 	if d.sync != sync && !errors.Is(d.reader.Error, io.EOF) {


### PR DESCRIPTION
This ensures that short reads (unexpected EOF) returns errors properly in the reader.