### PR TITLE
fix: readByte returns errors on unexpected EOF

### DIFF
--- a/decoder_native_test.go
+++ b/decoder_native_test.go
@@ -54,6 +54,20 @@ func TestDecoder_BoolInvalidSchema(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDecoder_BoolEof(t *testing.T) {
+	defer ConfigTeardown()
+
+	data := []byte{0x4}
+	schema := `{"fields":[{"name":"B","type":{"type":"int"}},{"name":"A","type":{"type":"boolean"}}],"name":"foo","type":"record"}`
+	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	var b any
+	err = dec.Decode(&b)
+
+	assert.Error(t, err)
+}
+
 func TestDecoder_Int(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/reader.go
+++ b/reader.go
@@ -99,6 +99,7 @@ func (r *Reader) loadMore() bool {
 func (r *Reader) readByte() byte {
 	if r.head == r.tail {
 		if !r.loadMore() {
+			r.Error = io.ErrUnexpectedEOF
 			return 0
 		}
 	}


### PR DESCRIPTION
This ensures that readByte (unexpected EOF) returns errors properly in the reader.