### PR TITLE
fix: reader int/long setting head > tail

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -171,20 +171,22 @@ func (r *Reader) ReadInt() int32 {
 		}
 
 		// Consume what it is in the buffer.
-		for i, b := range r.buf[r.head:tail] {
+		var i int
+		for _, b := range r.buf[r.head:tail] {
 			v |= uint32(b&0x7f) << s
 			if b&0x80 == 0 {
 				r.head += i + 1
 				return int32((v >> 1) ^ -(v & 1))
 			}
 			s += 7
-			n++
+			i++
 		}
 		if n >= maxIntBufSize {
 			r.ReportError("ReadInt", "int overflow")
 			return 0
 		}
-		r.head += n
+		r.head += i
+		n += i
 
 		// We ran out of buffer and are not at the end of the int,
 		// Read more into the buffer.
@@ -216,20 +218,22 @@ func (r *Reader) ReadLong() int64 {
 		}
 
 		// Consume what it is in the buffer.
-		for i, b := range r.buf[r.head:tail] {
+		var i int
+		for _, b := range r.buf[r.head:tail] {
 			v |= uint64(b&0x7f) << s
 			if b&0x80 == 0 {
 				r.head += i + 1
 				return int64((v >> 1) ^ -(v & 1))
 			}
 			s += 7
-			n++
+			i++
 		}
 		if n >= maxLongBufSize {
 			r.ReportError("ReadLong", "int overflow")
 			return 0
 		}
-		r.head += n
+		r.head += i
+		n += i
 
 		// We ran out of buffer and are not at the end of the long,
 		// Read more into the buffer.

--- a/reader_test.go
+++ b/reader_test.go
@@ -254,6 +254,18 @@ func TestReader_ReadInt(t *testing.T) {
 	}
 }
 
+func TestReader_ReadIntShortReadAcrossBuffer(t *testing.T) {
+	data := []byte{0xe2, 0xa2, 0xf3, 0xad}
+	r := avro.NewReader(bytes.NewReader(data), 3)
+
+	_ = r.ReadInt()
+
+	assert.NotPanics(t, func() {
+		b := make([]byte, 3)
+		r.Read(b)
+	})
+}
+
 func TestReader_ReadLong(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -357,6 +369,18 @@ func TestReader_ReadLong(t *testing.T) {
 			assert.Equal(t, test.want, got)
 		})
 	}
+}
+
+func TestReader_ReadLongShortReadAcrossBuffer(t *testing.T) {
+	data := []byte{0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	r := avro.NewReader(bytes.NewReader(data), 8)
+
+	_ = r.ReadLong()
+
+	assert.NotPanics(t, func() {
+		b := make([]byte, 3)
+		r.Read(b)
+	})
 }
 
 func TestReader_ReadFloat(t *testing.T) {


### PR DESCRIPTION
This fixes an issue that occurs when ReadInt/Long encounter an error across a buffer boundary, causing `r.head` to be greater than `r.tail`.