### PR TITLE
fix: 32bit build fails

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ const (
 	defaultMaxByteSliceSize = 1_048_576 // 1 MiB
 	// Max allocation size for an array due to the limit in number of bits in a heap address:
 	// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
-	maxAllocSize = int(1 << 48)
+	maxAllocSize = int64(1 << 48)
 )
 
 // DefaultConfig is the default API.
@@ -279,8 +279,8 @@ func (c *frozenConfig) getMaxByteSliceSize() int {
 
 func (c *frozenConfig) getMaxSliceAllocSize() int {
 	size := c.config.MaxSliceAllocSize
-	if size > maxAllocSize || size <= 0 {
-		return maxAllocSize
+	if int64(size) > maxAllocSize || size <= 0 {
+		return int(maxAllocSize)
 	}
 	return size
 }

--- a/config.go
+++ b/config.go
@@ -10,9 +10,6 @@ import (
 
 const (
 	defaultMaxByteSliceSize = 1_048_576 // 1 MiB
-	// Max allocation size for an array due to the limit in number of bits in a heap address:
-	// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
-	maxAllocSize = int64(1 << 48)
 )
 
 // DefaultConfig is the default API.
@@ -279,8 +276,8 @@ func (c *frozenConfig) getMaxByteSliceSize() int {
 
 func (c *frozenConfig) getMaxSliceAllocSize() int {
 	size := c.config.MaxSliceAllocSize
-	if int64(size) > maxAllocSize || size <= 0 {
-		return int(maxAllocSize)
+	if size > maxAllocSize || size <= 0 {
+		return maxAllocSize
 	}
 	return size
 }

--- a/config_386.go
+++ b/config_386.go
@@ -1,0 +1,8 @@
+package avro
+
+import "math"
+
+// Max allocation size for an array due to the limit in number of bits in a heap address:
+// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L190
+// 32-bit systems accept the full 32bit address space
+const maxAllocSize = math.MaxInt

--- a/config_x64.go
+++ b/config_x64.go
@@ -1,0 +1,7 @@
+//go:build !386
+
+package avro
+
+// Max allocation size for an array due to the limit in number of bits in a heap address:
+// https://github.com/golang/go/blob/7f76c00fc5678fa782708ba8fece63750cb89d03/src/runtime/malloc.go#L183
+const maxAllocSize = int(1 << 48)


### PR DESCRIPTION
The Apache Arrow project uses this library for supporting reading Avro into Apache Arrow record batches. A dependabot alert to update to a new version fails building in the CI due to usage of `int(1 << 48)` which fails on the cross-build CI for 32-bit systems [link](https://github.com/apache/arrow/actions/runs/8881814891/job/24385052137?pr=41438).

If we explicitly type it as an `int64` this alleviates the problem and allows this library to continue to successfully build on 32-bit systems.