### PR TITLE
fix: map record decodes in union case

### DIFF
--- a/codec_record.go
+++ b/codec_record.go
@@ -275,7 +275,7 @@ func decoderOfRecord(d *decoderContext, schema Schema, typ reflect2.Type) ValDec
 
 		fields[i] = recordMapDecoderField{
 			name:    field.Name(),
-			decoder: newEfaceDecoder(d, field.Type()),
+			decoder: decoderOfType(d, field.Type(), mapType.Elem()),
 		}
 	}
 

--- a/decoder_record_test.go
+++ b/decoder_record_test.go
@@ -236,13 +236,14 @@ func TestDecoder_RecordEmbeddedIntStruct(t *testing.T) {
 func TestDecoder_RecordMap(t *testing.T) {
 	defer ConfigTeardown()
 
-	data := []byte{0x36, 0x06, 0x66, 0x6f, 0x6f}
+	data := []byte{0x36, 0x06, 0x66, 0x6f, 0x6f, 0x02, 0x06, 0x66, 0x6f, 0x6f}
 	schema := `{
 	"type": "record",
 	"name": "test",
 	"fields" : [
 		{"name": "a", "type": "long"},
-	    {"name": "b", "type": "string"}
+	    {"name": "b", "type": "string"},
+		{"name": "c", "type": ["null","string"]}
 	]
 }`
 	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
@@ -252,7 +253,7 @@ func TestDecoder_RecordMap(t *testing.T) {
 	err = dec.Decode(&got)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{"a": int64(27), "b": "foo"}, got)
+	assert.Equal(t, map[string]any{"a": int64(27), "b": "foo", "c": "foo"}, got)
 }
 
 func TestDecoder_RecordMapInvalidKey(t *testing.T) {


### PR DESCRIPTION
This fixes a potential bug where map record decodes where optimised changing how unions are decoded. 

See https://github.com/hamba/avro/commit/aa7f619fd2c0362a8b649c4d7b7f0d3317bb69dd#diff-76d79b5f35aac6861a49a410fbb009f12801faadce2db0f35d21f4c50bfe3796R279

Fixes #386