### PR TITLE
chore: support go 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ "1.21", "1.22" ]
+        go-version: [ "1.22", "1.23" ]
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.58.0
+      GOLANGCI_LINT_VERSION: v1.60.1
 
     steps:
       - name: Install Go
@@ -37,7 +37,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          skip-pkg-cache: true
 
       - name: Run tests
         run: go test -covermode=count -coverprofile=coverage.out ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,18 +10,8 @@ linters:
   enable-all: true
   disable:
     - cyclop # duplicate of gocyclo
-    - deadcode # deprecated
     - execinquery # deprecated
-    - exhaustivestruct # deprecated
-    - golint # deprecated
     - gomnd # deprecated
-    - ifshort # deprecated
-    - interfacer # deprecated
-    - maligned # deprecated
-    - nosnakecase # deprecated
-    - scopelint # deprecated
-    - structcheck # deprecated
-    - varcheck # deprecated
     - depguard
     - err113
     - exhaustive

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Note that this variable is global, so ideally you'd need to unset it after you'r
 ## Go Version Support
 
 This library supports the last two versions of Go. While the minimum Go version is
-not guarantee to increase along side Go, it may jump from time to time to support 
+not guaranteed to increase along side Go, it may jump from time to time to support 
 additional features. This will be not be considered a breaking change.
 
 ## Who uses hamba/avro?

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hamba/avro/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/ettle/strcase v0.2.0

--- a/reader.go
+++ b/reader.go
@@ -287,7 +287,7 @@ func (r *Reader) readBytes(op string) []byte {
 	if size == 0 {
 		return []byte{}
 	}
-	if max := r.cfg.getMaxByteSliceSize(); max > 0 && size > max {
+	if maxSize := r.cfg.getMaxByteSliceSize(); maxSize > 0 && size > maxSize {
 		fnName := "Read" + strings.ToTitle(op)
 		r.ReportError(fnName, "size is greater than `Config.MaxByteSliceSize`")
 		return nil


### PR DESCRIPTION
This adds support for Go 1.23, removing support for Go 1.21.