### PR TITLE
fix: ref already seen schemas in deref walk

### DIFF
--- a/schema_parse.go
+++ b/schema_parse.go
@@ -564,6 +564,13 @@ func derefSchema(schema Schema) Schema {
 
 	return walkSchema(schema, func(schema Schema) Schema {
 		if ns, ok := schema.(NamedSchema); ok {
+			if _, hasSeen := seen[ns.FullName()]; hasSeen {
+				// This NamedSchema has been seen in this run, it needs
+				// to be turned into a reference. It is possible it was
+				// dereferenced in a previous run.
+				return NewRefSchema(ns)
+			}
+
 			seen[ns.FullName()] = struct{}{}
 			return schema
 		}


### PR DESCRIPTION
This references previously dereferenced schemas when parsing.

There is an edge case, where in multiple parse calls, a schema has been dereferenced twice. If this ends up in the same schema, the second "copy" needs to be re-referenced.

Fixes #437