### PR TITLE
Add custom logical types

### DIFF
--- a/config_internal_test.go
+++ b/config_internal_test.go
@@ -182,3 +182,30 @@ func TestConfig_DisableCache_DoesNotReuseEncoders(t *testing.T) {
 
 	assert.NotSame(t, enc1, enc2)
 }
+
+func TestConfig_RegisterCustomLogicalType(t *testing.T) {
+	type testObj struct {
+		A int64 `avro:"a"`
+	}
+
+	api := Config{
+		TagKey:         "test",
+		BlockLength:    2,
+		DisableCaching: true,
+	}.Freeze()
+	cfg := api.(*frozenConfig)
+
+	schema := MustParse(`{
+	"type": "record",
+	"name": "test",
+	"fields" : [
+		{"name": "a", "type": "long"}
+	]
+}`)
+	typ := reflect2.TypeOfPtr(testObj{})
+
+	enc1 := cfg.EncoderOf(schema, typ)
+	enc2 := cfg.EncoderOf(schema, typ)
+
+	assert.NotSame(t, enc1, enc2)
+}

--- a/schema.go
+++ b/schema.go
@@ -97,6 +97,9 @@ func getCustomLogicalSchema(ltyp LogicalType) LogicalSchema {
 	return nil
 }
 
+// RegisterCustomLogicalType registers a custom logical type that is not part of the Avro specification.
+// It returns an error if the logical type conflicts with a predefined logical type or if the logical
+// type has already been registered.
 func RegisterCustomLogicalType(ltyp LogicalType) error {
 	// Ensure that the custom logical type does not overwrite a primitive type
 	switch ltyp {
@@ -461,7 +464,10 @@ func WithAliases(aliases []string) SchemaOption {
 	}
 }
 
-// WithCustomLogicalType sets the logical type on a schema.
+// WithCustomLogicalType sets a custom logical type on a schema.
+// Make sure to register the custom logical type before using it,
+// otherwise it will be ignored.
+// See RegisterCustomLogicalType.
 func WithCustomLogicalType(ltyp LogicalType) SchemaOption {
 	return func(opts *schemaConfig) {
 		opts.customLogicalSchema = getCustomLogicalSchema(ltyp)
@@ -653,6 +659,7 @@ func (s *RecordSchema) Type() Type {
 	return Record
 }
 
+// Logical returns the logical schema or nil.
 func (s *RecordSchema) Logical() LogicalSchema {
 	return s.logical
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -983,6 +983,18 @@ func TestFixedSchema_HandlesProps(t *testing.T) {
 }
 
 func TestSchema_LogicalTypes(t *testing.T) {
+	customType := avro.LogicalType("customType")
+	err := avro.RegisterCustomLogicalType(customType)
+	require.NoError(t, err)
+
+	// Should not be able to register the same type twice
+	err = avro.RegisterCustomLogicalType(customType)
+	require.Error(t, err)
+
+	// should not be able to register a type with the same name as a built-in type
+	err = avro.RegisterCustomLogicalType(avro.Date)
+	require.Error(t, err)
+
 	tests := []struct {
 		name            string
 		schema          string
@@ -996,6 +1008,41 @@ func TestSchema_LogicalTypes(t *testing.T) {
 			schema:      `{"type": "int", "logicalType": "test"}`,
 			wantType:    avro.Int,
 			wantLogical: false,
+		},
+		{
+			name:            "Primitive Custom Type",
+			schema:          `{"type": "int", "logicalType": "customType"}`,
+			wantType:        avro.Int,
+			wantLogical:     true,
+			wantLogicalType: customType,
+		},
+		{
+			name:            "Enum Custom Type",
+			schema:          `{"type":"enum", "name":"test", "namespace": "org.hamba.avro", "symbols":["TEST"], "logicalType": "customType"}`,
+			wantType:        avro.Enum,
+			wantLogical:     true,
+			wantLogicalType: customType,
+		},
+		{
+			name:            "Array Custom Type",
+			schema:          `{"type":"array", "items": "int", "logicalType": "customType"}`,
+			wantType:        avro.Array,
+			wantLogical:     true,
+			wantLogicalType: customType,
+		},
+		{
+			name:            "Map Custom Type",
+			schema:          `{"type":"map", "values": "int", "logicalType": "customType"}`,
+			wantType:        avro.Map,
+			wantLogical:     true,
+			wantLogicalType: customType,
+		},
+		{
+			name:            "Record Custom Type",
+			schema:          `{"type": "record", "name": "Foo", "fields": [{"name": "baz", "type": "string"}], "logicalType": "customType"}`,
+			wantType:        avro.Record,
+			wantLogical:     true,
+			wantLogicalType: customType,
 		},
 		{
 			name:            "Date",


### PR DESCRIPTION
closes #435 

Hi @nrwiersma 

This PR adds the possibility to register custom logical types for the schema. These logicaltypes are primitive, and does not include logic for handling custom encoding/decoding, but simply adds the the custom logicalType to be referenced in the schemas.

I have added the `WithCustomLogicalType` function as a SchemaOption, but not at all schemas use this option - I saw this pattern was already used for other schema options. 

Let me know what you think :)