### PR TITLE
Fix: record MarshalJSON in case of default record with nullable field

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -16,7 +16,13 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-var nullDefault = struct{}{}
+type nullDefaultType struct{}
+
+func (nullDefaultType) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
+}
+
+var nullDefault nullDefaultType = struct{}{}
 
 var (
 	schemaReserved = []string{


### PR DESCRIPTION
I came across the following case where record `MarshalJSON` generates an Invalid schema, which `avro.Parse` fails to parse, returning the error:

> invalid default for field a. <nil> not a record

Schema:
```json
{
  "type": "record",
  "name": "test",
  "namespace": "org.hamba.avro",
  "fields": [
    {
      "name": "a",
      "type": {
        "type": "record",
        "name": "test2",
        "fields": [
          {
            "name": "b",
            "type": "int"
          },
          {
            "name": "c",
            "type": [
              "null",
              "int"
            ]
          }
        ]
      },
      "default": {
        "b": 1,
        "c": null
      }
    }
  ]
}
```

The generated invalid schema:

```json
{
  "name": "org.hamba.avro.test",
  "type": "record",
  "fields": [
    {
      "name": "a",
      "type": {
        "name": "org.hamba.avro.test2",
        "type": "record",
        "fields": [
          {
            "name": "b",
            "type": "int"
          },
          {
            "name": "c",
            "type": [
              "null",
              "int"
            ]
          }
        ]
      },
      "default": {
        "b": 1,
        "c": {}
      }
    }
  ]
}
```

The default value of `c` should be `null` instead of an empty JSON object.

If I got it right, a fix could be to define a custom `MarshalJSON` for the `nullDefault` value:

```go
type nullDefaultType struct{}

func (nullDefaultType) MarshalJSON() ([]byte, error) {
	return []byte("null"), nil
}

var nullDefault nullDefaultType = struct{}{}
```

