### PR TITLE
Fix: decode in the case of field missing in both writer binary and reader struct.

### DIFF
--- a/codec_record.go
+++ b/codec_record.go
@@ -76,9 +76,17 @@ func decoderOfStruct(d *decoderContext, schema Schema, typ reflect2.Type) ValDec
 				}
 			}
 		}
-
-		// Skip field if it doesnt exist
+		// Skip field if it doesn't exist
 		if sf == nil {
+			// If the field value doesn't exist in the binary, ignore it instead of
+			// appending a 'SkipDecoder'.
+			//
+			// Note: 'SkipDecoder' performs a read and moves the cursor, which,
+			// in this case, will lead to a dirty read.
+			if field.action == FieldSetDefault {
+				continue
+			}
+
 			fields = append(fields, &structFieldDecoder{
 				decoder: createSkipDecoder(field.Type()),
 			})

--- a/schema_compatibility_test.go
+++ b/schema_compatibility_test.go
@@ -978,13 +978,12 @@ func TestSchemaCompatibility_ResolveWithComplexUnion(t *testing.T) {
 }
 
 func TestSchemaCompatibility_ResolveWithFieldMissingInWriterAndReaderStruct(t *testing.T) {
-
 	w := avro.MustParse(`{
-						"type":"record", "name":"test", "namespace": "org.hamba.avro", 
-						"fields":[
-							{"name": "a", "type": "string"}
-						]
-					}`)
+				"type":"record", "name":"test", "namespace": "org.hamba.avro", 
+				"fields":[
+					{"name": "a", "type": "string"}
+				]
+			}`)
 
 	r := avro.MustParse(`{
 				"type":"record", "name":"test", "namespace": "org.hamba.avro", 
@@ -995,25 +994,25 @@ func TestSchemaCompatibility_ResolveWithFieldMissingInWriterAndReaderStruct(t *t
 				]
 			}`)
 
-	type TW struct {
+	type TestW struct {
 		A string `avro:"a"`
 	}
-	value := TW{A: "abc"}
+	value := TestW{A: "abc"}
 
 	b, err := avro.Marshal(w, value)
 	assert.NoError(t, err)
 
-	sch, err := avro.NewSchemaCompatibility().Resolve(r, w)
+	schema, err := avro.NewSchemaCompatibility().Resolve(r, w)
 	assert.NoError(t, err)
 
-	type TR struct {
+	type TestR struct {
 		A string `avro:"a"`
 		C string `avro:"c"`
 	}
-	want := TR{A: "abc", C: "foo"}
+	want := TestR{A: "abc", C: "foo"}
 
-	var result TR
-	err = avro.Unmarshal(sch, b, &result)
+	var result TestR
+	err = avro.Unmarshal(schema, b, &result)
 	assert.NoError(t, err)
 
 	assert.Equal(t, want, result)


### PR DESCRIPTION
I think I overlooked an edge case the last time I worked on schema evolution:

If a field is missing in both the binary and the reader struct, it should be ignored rather than calling skipDecoder (which technically performs a read and moves the cursor).

The current implementation might perform a dirty read, causing errors like:

> unexpected EOF

> ReadString: size is greater than `Config.MaxByteSliceSize`