### PR TITLE
chore: bump min Go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         go-version: [ "1.22", "1.23" ]
     env:
-      GOLANGCI_LINT_VERSION: v1.60.1
+      GOLANGCI_LINT_VERSION: v1.61.0
 
     steps:
       - name: Install Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,16 @@ run:
 linters-settings:
   gofumpt:
     extra-rules: true
+  gosec:
+    excludes:
+      - G115
 
 linters:
   enable-all: true
   disable:
     - cyclop # duplicate of gocyclo
     - execinquery # deprecated
+    - exportloopref # deprecated
     - gomnd # deprecated
     - depguard
     - err113

--- a/codec_fixed.go
+++ b/codec_fixed.go
@@ -115,13 +115,13 @@ type fixedCodec struct {
 }
 
 func (c *fixedCodec) Decode(ptr unsafe.Pointer, r *Reader) {
-	for i := 0; i < c.arrayType.Len(); i++ {
+	for i := range c.arrayType.Len() {
 		c.arrayType.UnsafeSetIndex(ptr, i, reflect2.PtrOf(r.readByte()))
 	}
 }
 
 func (c *fixedCodec) Encode(ptr unsafe.Pointer, w *Writer) {
-	for i := 0; i < c.arrayType.Len(); i++ {
+	for i := range c.arrayType.Len() {
 		bytePtr := c.arrayType.UnsafeGetIndex(ptr, i)
 		w.writeByte(*((*byte)(bytePtr)))
 	}

--- a/codec_map.go
+++ b/codec_map.go
@@ -67,7 +67,7 @@ func (d *mapDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 			break
 		}
 
-		for i := int64(0); i < l; i++ {
+		for range l {
 			keyPtr := reflect2.PtrOf(r.ReadString())
 			elemPtr := d.elemType.UnsafeNew()
 			d.decoder.Decode(elemPtr, r)
@@ -115,7 +115,7 @@ func (d *mapDecoderUnmarshaler) Decode(ptr unsafe.Pointer, r *Reader) {
 			break
 		}
 
-		for i := int64(0); i < l; i++ {
+		for range l {
 			keyPtr := d.keyType.UnsafeNew()
 			keyObj := d.keyType.UnsafeIndirect(keyPtr)
 			if reflect2.IsNil(keyObj) {

--- a/codec_record.go
+++ b/codec_record.go
@@ -465,7 +465,7 @@ func describeStruct(tagKey string, typ reflect2.Type) *structDescriptor {
 			}
 			visited[rtype] = true
 
-			for i := 0; i < f.anon.NumField(); i++ {
+			for i := range f.anon.NumField() {
 				field := f.anon.Field(i).(*reflect2.UnsafeStructField)
 				isUnexported := field.PkgPath() != ""
 

--- a/codec_skip.go
+++ b/codec_skip.go
@@ -152,7 +152,7 @@ func (d *sliceSkipDecoder) Decode(_ unsafe.Pointer, r *Reader) {
 			continue
 		}
 
-		for i := 0; i < int(l); i++ {
+		for range l {
 			d.decoder.Decode(nil, r)
 		}
 	}
@@ -183,7 +183,7 @@ func (d *mapSkipDecoder) Decode(_ unsafe.Pointer, r *Reader) {
 			continue
 		}
 
-		for i := 0; i < int(l); i++ {
+		for range l {
 			r.SkipString()
 			d.decoder.Decode(nil, r)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,23 +1,25 @@
 module github.com/hamba/avro/v2
 
-go 1.21
+go 1.22.0
+
+toolchain go1.23.1
 
 require (
 	github.com/ettle/strcase v0.2.0
 	github.com/golang/snappy v0.0.4
 	github.com/json-iterator/go v1.1.12
-	github.com/klauspost/compress v1.17.9
+	github.com/klauspost/compress v1.17.10
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/tools v0.24.0
+	golang.org/x/tools v0.25.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.20.0 // indirect
+	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.17.10 h1:oXAz+Vh0PMUvJczoi+flxpnBEPxoER1IaAnU/NMPtT0=
+github.com/klauspost/compress v1.17.10/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -23,12 +23,12 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
-golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
-golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
+golang.org/x/tools v0.25.0 h1:oFU9pkj/iJgs+0DT+VMHrx+oBKs/LJMV+Uvg78sl+fE=
+golang.org/x/tools v0.25.0/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/crc64/crc64.go
+++ b/pkg/crc64/crc64.go
@@ -21,9 +21,9 @@ type Table [256]uint64
 
 func makeTable() *Table {
 	t := new(Table)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		fp := uint64(i)
-		for j := 0; j < 8; j++ {
+		for range 8 {
 			fp = (fp >> 1) ^ (Empty & -(fp & 1))
 		}
 		t[i] = fp
@@ -68,7 +68,7 @@ func (d *digest) Reset() {
 
 // Write accumulatively adds the given data to the checksum.
 func (d *digest) Write(p []byte) (n int, err error) {
-	for i := 0; i < len(p); i++ {
+	for i := range p {
 		d.crc = (d.crc >> 8) ^ d.tab[(int)(byte(d.crc)^p[i])&0xff]
 	}
 

--- a/reader_generic.go
+++ b/reader_generic.go
@@ -133,7 +133,7 @@ func (r *Reader) ReadArrayCB(fn func(*Reader) bool) {
 		if l == 0 {
 			break
 		}
-		for i := 0; i < int(l); i++ {
+		for range l {
 			fn(r)
 		}
 	}
@@ -147,7 +147,7 @@ func (r *Reader) ReadMapCB(fn func(*Reader, string) bool) {
 			break
 		}
 
-		for i := 0; i < int(l); i++ {
+		for range l {
 			field := r.ReadString()
 			fn(r, field)
 		}

--- a/schema.go
+++ b/schema.go
@@ -1735,7 +1735,7 @@ func isValidDefaultBytes(def string) ([]byte, bool) {
 	runes := []rune(def)
 	l := len(runes)
 	b := make([]byte, l)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		if runes[i] < 0 || runes[i] > 255 {
 			return nil, false
 		}


### PR DESCRIPTION
This bumps the minimum Go version to v1.22 to allow other dependencies to be updated. It subsequently fixes new linter issues that come with the Go version change.