### PR TITLE
feat: allow empty namespaces

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -252,7 +252,7 @@ func parseProtocol(m map[string]any, seen seenCache, cache *SchemaCache) (*Proto
 		return nil, fmt.Errorf("avro: error decoding protocol: %w", err)
 	}
 
-	if err := checkParsedName(p.Protocol, p.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
+	if err := checkParsedName(p.Protocol); err != nil {
 		return nil, err
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -54,6 +54,11 @@ func TestParseProtocol(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name:    "Empty Namespace",
+			schema:  `{"protocol":"test", "namespace": ""}`,
+			wantErr: assert.NoError,
+		},
+		{
 			name:    "Invalid Json",
 			schema:  `{`,
 			wantErr: assert.Error,
@@ -81,11 +86,6 @@ func TestParseProtocol(t *testing.T) {
 		{
 			name:    "Invalid Namespace",
 			schema:  `{"protocol":"test", "namespace": "org.hamba.avro+"}`,
-			wantErr: assert.Error,
-		},
-		{
-			name:    "Empty Namespace",
-			schema:  `{"protocol":"test", "namespace": ""}`,
 			wantErr: assert.Error,
 		},
 		{

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -224,7 +224,7 @@ func parseRecord(typ Type, namespace string, m map[string]any, seen seenCache, c
 		return nil, fmt.Errorf("avro: error decoding record: %w", err)
 	}
 
-	if err := checkParsedName(r.Name, r.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
+	if err := checkParsedName(r.Name); err != nil {
 		return nil, err
 	}
 	if r.Namespace == "" {
@@ -294,7 +294,7 @@ func parseField(namespace string, m map[string]any, seen seenCache, cache *Schem
 		return nil, fmt.Errorf("avro: error decoding field: %w", err)
 	}
 
-	if err := checkParsedName(f.Name, "", false); err != nil {
+	if err := checkParsedName(f.Name); err != nil {
 		return nil, err
 	}
 
@@ -340,7 +340,7 @@ func parseEnum(namespace string, m map[string]any, seen seenCache, cache *Schema
 		return nil, fmt.Errorf("avro: error decoding enum: %w", err)
 	}
 
-	if err := checkParsedName(e.Name, e.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
+	if err := checkParsedName(e.Name); err != nil {
 		return nil, err
 	}
 	if e.Namespace == "" {
@@ -451,7 +451,7 @@ func parseFixed(namespace string, m map[string]any, seen seenCache, cache *Schem
 		return nil, fmt.Errorf("avro: error decoding fixed: %w", err)
 	}
 
-	if err := checkParsedName(f.Name, f.Namespace, hasKey(meta.Keys, "namespace")); err != nil {
+	if err := checkParsedName(f.Name); err != nil {
 		return nil, err
 	}
 	if f.Namespace == "" {
@@ -529,12 +529,9 @@ func fullName(namespace, name string) string {
 	return namespace + "." + name
 }
 
-func checkParsedName(name, ns string, hasNS bool) error {
+func checkParsedName(name string) error {
 	if name == "" {
 		return errors.New("avro: non-empty name key required")
-	}
-	if hasNS && ns == "" {
-		return errors.New("avro: namespace key must be non-empty or omitted")
 	}
 	return nil
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -192,6 +192,11 @@ func TestRecordSchema(t *testing.T) {
 			wantErr: require.NoError,
 		},
 		{
+			name:    "Empty Namespace",
+			schema:  `{"type":"record", "name":"test", "namespace": "", "fields":[{"name": "intField", "type": "int"}]}`,
+			wantErr: require.NoError,
+		},
+		{
 			name:    "Invalid Name First Char",
 			schema:  `{"type":"record", "name":"0test", "namespace": "org.hamba.avro", "fields":[{"name": "field", "type": "int"}]}`,
 			wantErr: require.Error,
@@ -214,11 +219,6 @@ func TestRecordSchema(t *testing.T) {
 		{
 			name:    "Invalid Namespace",
 			schema:  `{"type":"record", "name":"test", "namespace": "org.hamba.avro+", "fields":[{"name": "field", "type": "int"}]}`,
-			wantErr: require.Error,
-		},
-		{
-			name:    "Empty Namespace",
-			schema:  `{"type":"record", "name":"test", "namespace": "", "fields":[{"name": "intField", "type": "int"}]}`,
 			wantErr: require.Error,
 		},
 		{
@@ -287,6 +287,11 @@ func TestErrorRecordSchema(t *testing.T) {
 			wantErr:    require.NoError,
 		},
 		{
+			name:    "Empty Namespace",
+			schema:  `{"type":"error", "name":"test", "namespace": "", "fields":[{"name": "intField", "type": "int"}]}`,
+			wantErr: require.NoError,
+		},
+		{
 			name:    "Invalid Name First Char",
 			schema:  `{"type":"error", "name":"0test", "namespace": "org.hamba.avro", "fields":[{"name": "field", "type": "int"}]}`,
 			wantErr: require.Error,
@@ -309,11 +314,6 @@ func TestErrorRecordSchema(t *testing.T) {
 		{
 			name:    "Invalid Namespace",
 			schema:  `{"type":"error", "name":"test", "namespace": "org.hamba.avro+", "fields":[{"name": "field", "type": "int"}]}`,
-			wantErr: require.Error,
-		},
-		{
-			name:    "Empty Namespace",
-			schema:  `{"type":"error", "name":"test", "namespace": "", "fields":[{"name": "intField", "type": "int"}]}`,
 			wantErr: require.Error,
 		},
 	}
@@ -641,6 +641,11 @@ func TestEnumSchema(t *testing.T) {
 			wantErr:     require.NoError,
 		},
 		{
+			name:    "Empty Namespace",
+			schema:  `{"type":"enum", "name":"test", "namespace": "", "symbols":["TEST"]}`,
+			wantErr: require.NoError,
+		},
+		{
 			name:    "Invalid Name",
 			schema:  `{"type":"enum", "name":"test+", "namespace": "org.hamba.avro", "symbols":["TEST"]}`,
 			wantErr: require.Error,
@@ -658,11 +663,6 @@ func TestEnumSchema(t *testing.T) {
 		{
 			name:    "Invalid Namespace",
 			schema:  `{"type":"enum", "name":"test", "namespace": "org.hamba.avro+", "symbols":["TEST"]}`,
-			wantErr: require.Error,
-		},
-		{
-			name:    "Empty Namespace",
-			schema:  `{"type":"enum", "name":"test", "namespace": "", "symbols":["TEST"]}`,
 			wantErr: require.Error,
 		},
 		{
@@ -932,6 +932,11 @@ func TestFixedSchema(t *testing.T) {
 			wantErr:         require.NoError,
 		},
 		{
+			name:    "Empty Namespace",
+			schema:  `{"type":"fixed", "name":"test", "namespace": "", "size": 12}`,
+			wantErr: require.NoError,
+		},
+		{
 			name:    "Invalid Name",
 			schema:  `{"type":"fixed", "name":"test+", "namespace": "org.hamba.avro", "size": 12}`,
 			wantErr: require.Error,
@@ -949,11 +954,6 @@ func TestFixedSchema(t *testing.T) {
 		{
 			name:    "Invalid Namespace",
 			schema:  `{"type":"fixed", "name":"test", "namespace": "org.hamba.avro+", "size": 12}`,
-			wantErr: require.Error,
-		},
-		{
-			name:    "Empty Namespace",
-			schema:  `{"type":"fixed", "name":"test", "namespace": "", "size": 12}`,
 			wantErr: require.Error,
 		},
 		{


### PR DESCRIPTION
The Avro spec has changed to allow empty namespaces as null namespaces:
> A namespace is a dot-separated sequence of such names. The empty string may also be used as a namespace to indicate the null namespace.

This PR adjusts validations and tests to allow support this new spec case.

Fixes #457