### PR TITLE
Improve OCF encoder/decoder handling of dynamic types

### DIFF
--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -52,9 +52,8 @@ type Header struct {
 }
 
 type decoderConfig struct {
-	DecoderConfig   avro.API
-	SchemaCache     *avro.SchemaCache
-	SchemaMarshaler func(avro.Schema) ([]byte, error)
+	DecoderConfig avro.API
+	SchemaCache   *avro.SchemaCache
 }
 
 // DecoderFunc represents a configuration function for Decoder.
@@ -75,14 +74,6 @@ func WithDecoderSchemaCache(cache *avro.SchemaCache) DecoderFunc {
 	}
 }
 
-// WithDecoderSchemaMarshaler sets the schema marshaler for the decoder.
-// If not specified, defaults to DefaultSchemaMarshaler.
-func WithDecoderSchemaMarshaler(m func(avro.Schema) ([]byte, error)) DecoderFunc {
-	return func(cfg *decoderConfig) {
-		cfg.SchemaMarshaler = m
-	}
-}
-
 // Decoder reads and decodes Avro values from a container file.
 type Decoder struct {
 	reader      *avro.Reader
@@ -100,9 +91,8 @@ type Decoder struct {
 // NewDecoder returns a new decoder that reads from reader r.
 func NewDecoder(r io.Reader, opts ...DecoderFunc) (*Decoder, error) {
 	cfg := decoderConfig{
-		DecoderConfig:   avro.DefaultConfig,
-		SchemaCache:     avro.DefaultSchemaCache,
-		SchemaMarshaler: DefaultSchemaMarshaler,
+		DecoderConfig: avro.DefaultConfig,
+		SchemaCache:   avro.DefaultSchemaCache,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -256,9 +246,9 @@ func WithEncoderSchemaCache(cache *avro.SchemaCache) EncoderFunc {
 	}
 }
 
-// WithEncoderSchemaMarshaler sets the schema marshaler for the encoder.
+// WithSchemaMarshaler sets the schema marshaler for the encoder.
 // If not specified, defaults to DefaultSchemaMarshaler.
-func WithEncoderSchemaMarshaler(m func(avro.Schema) ([]byte, error)) EncoderFunc {
+func WithSchemaMarshaler(m func(avro.Schema) ([]byte, error)) EncoderFunc {
 	return func(cfg *encoderConfig) {
 		cfg.SchemaMarshaler = m
 	}

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -1074,7 +1074,6 @@ func TestWithSchemaMarshaler(t *testing.T) {
 				"name": "meta",
 				"type": {
 					"type": "array",
-					"logicalType": "map",
 					"items": {
 						"type": "record",
 						"name": "FooMetadataEntry",
@@ -1146,9 +1145,6 @@ func TestWithSchemaMarshaler(t *testing.T) {
 		},
 		"fields.2": {
 			"field-id": 3.0,
-		},
-		"fields.2.type": {
-			"logicalType": "map",
 		},
 		"fields.2.type.items.fields.0": {
 			"field-id": 4.0,

--- a/ocf/testdata/full-schema.json
+++ b/ocf/testdata/full-schema.json
@@ -1,0 +1,43 @@
+{
+  "name": "foo.bar.baz.Bar",
+  "type": "record",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "field-id": 1
+    },
+    {
+      "name": "id",
+      "type": "long",
+      "field-id": 2
+    },
+    {
+      "name": "meta",
+      "type": {
+        "type": "array",
+        "items": {
+          "name": "foo.bar.baz.FooMetadataEntry",
+          "type": "record",
+          "fields": [
+            {
+              "name": "key",
+              "type": "string",
+              "field-id": 4
+            },
+            {
+              "name": "values",
+              "type": {
+                "type": "array",
+                "items": "string",
+                "element-id": 6
+              },
+              "field-id": 5
+            }
+          ]
+        }
+      },
+      "field-id": 3
+    }
+  ]
+}

--- a/schema.go
+++ b/schema.go
@@ -25,6 +25,10 @@ func (nullDefaultType) MarshalJSON() ([]byte, error) {
 var nullDefault nullDefaultType = struct{}{}
 
 var (
+	arrayReserved = []string{ // same as schemaReserved, but allows logicalType
+		"doc", "fields", "items", "name", "namespace", "size", "symbols",
+		"values", "type", "aliases", "precision", "scale",
+	}
 	schemaReserved = []string{
 		"doc", "fields", "items", "name", "namespace", "size", "symbols",
 		"values", "type", "aliases", "logicalType", "precision", "scale",
@@ -1072,7 +1076,7 @@ func NewArraySchema(items Schema, opts ...SchemaOption) *ArraySchema {
 	}
 
 	return &ArraySchema{
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props, arrayReserved),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		items:              items,
 	}

--- a/schema.go
+++ b/schema.go
@@ -25,10 +25,6 @@ func (nullDefaultType) MarshalJSON() ([]byte, error) {
 var nullDefault nullDefaultType = struct{}{}
 
 var (
-	arrayReserved = []string{ // same as schemaReserved, but allows logicalType
-		"doc", "fields", "items", "name", "namespace", "size", "symbols",
-		"values", "type", "aliases", "precision", "scale",
-	}
 	schemaReserved = []string{
 		"doc", "fields", "items", "name", "namespace", "size", "symbols",
 		"values", "type", "aliases", "logicalType", "precision", "scale",
@@ -1076,7 +1072,7 @@ func NewArraySchema(items Schema, opts ...SchemaOption) *ArraySchema {
 	}
 
 	return &ArraySchema{
-		properties:         newProperties(cfg.props, arrayReserved),
+		properties:         newProperties(cfg.props, schemaReserved),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		items:              items,
 	}


### PR DESCRIPTION
There are a few issues when dealing with dynamic types:
1. The existing code _always_ uses `avro.DefaultSchemaCache` when parsing schema JSON documents. But this pollutes a global variable with temporary, non-global state. If the schemas being processed have a high cardinality of distinct namespaces and/or types, this could be a memory pressure issue, since none of the cached schemas are ever purged.
2. The existing code requires a JSON document for the schema, but when dynamically building a schema, an `avro.Schema` is more natural and more type-safe.
3. The existing code stores the schema in the file's "avro.schema" metadata key using the output of `Schema.String()`. However, this schema _omits_ a lot of the schema details: in particular, it drops logical types and extra properties. I want to create files for use with Apache Iceberg, which has requirements that the file's Avro schema retain both logical types and some extra properties (mainly to capture Iceberg "field IDs" for everything). So in this branch, the logic now uses `json.Compact` on the input string, when the schema is provided as a JSON document, and `json.Marshal` on the avro schema, when the schema is provided as an `avro.Schema`. This makes sure that none of these details are lost. (I could use `json.Marshal` on the parsed schema in both cases, but it is more efficient to use `json.Compact` on an existing JSON document than to generate a new document.)

Lastly, this PR provides direct access to the parsed schema to users of an `ocf.Decoder`. Without this new accessor, users must re-parse the schema by getting the JSON from `dec.Metadata()["avro.schema"]` and calling `avro.ParseBytes...`.

I haven't added tests yet because I was hoping for some guidance. This doesn't really touch any meaningful logic. So maybe just a simple test to encode and decode files using a different schema cache, and verifying the default cache is not touched? And also a simple test to verify that the schema encoded into file metadata retains custom properties and logical types?