### PR TITLE
feat: remove property reservations

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -11,11 +11,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var (
-	protocolReserved = []string{"doc", "types", "messages", "protocol", "namespace"}
-	messageReserved  = []string{"doc", "response", "request", "errors", "one-way"}
-)
-
 type protocolConfig struct {
 	doc   string
 	props map[string]any
@@ -70,7 +65,7 @@ func NewProtocol(
 
 	p := &Protocol{
 		name:       n,
-		properties: newProperties(cfg.props, protocolReserved),
+		properties: newProperties(cfg.props),
 		types:      types,
 		messages:   messages,
 		doc:        cfg.doc,
@@ -145,7 +140,7 @@ func NewMessage(req *RecordSchema, resp Schema, errors *UnionSchema, oneWay bool
 	}
 
 	return &Message{
-		properties: newProperties(cfg.props, messageReserved),
+		properties: newProperties(cfg.props),
 		req:        req,
 		resp:       resp,
 		errs:       errors,

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -204,3 +204,13 @@ func TestParseProtocol_Types(t *testing.T) {
 	assert.Equal(t, wantPong, protocol.Types()[1].String())
 	assert.Equal(t, wantPongError, protocol.Types()[2].String())
 }
+
+func TestProtocol_String(t *testing.T) {
+	protocol, err := avro.ParseProtocolFile("testdata/echo.avpr")
+	require.NoError(t, err)
+
+	json := protocol.String()
+
+	want := `{"protocol":"Echo","namespace":"org.hamba.avro","types":[{"name":"org.hamba.avro.Ping","type":"record","fields":[{"name":"timestamp","type":"long"},{"name":"text","type":"string"}]},{"name":"org.hamba.avro.Pong","type":"record","fields":[{"name":"timestamp","type":"long"},{"name":"ping","type":"org.hamba.avro.Ping"}]},{"name":"org.hamba.avro.PongError","type":"error","fields":[{"name":"timestamp","type":"long"},{"name":"reason","type":"string"}]}],"messages":{"ping":{"request":[{"name":"ping","type":"org.hamba.avro.Ping"}],"response":"org.hamba.avro.Pong","errors":["org.hamba.avro.PongError"]}}}`
+	assert.Equal(t, want, json)
+}

--- a/schema.go
+++ b/schema.go
@@ -24,14 +24,6 @@ func (nullDefaultType) MarshalJSON() ([]byte, error) {
 
 var nullDefault nullDefaultType = struct{}{}
 
-var (
-	schemaReserved = []string{
-		"doc", "fields", "items", "name", "namespace", "size", "symbols",
-		"values", "type", "aliases", "logicalType", "precision", "scale",
-	}
-	fieldReserved = []string{"default", "doc", "name", "order", "type", "aliases"}
-)
-
 // Type is a schema type.
 type Type string
 
@@ -343,24 +335,8 @@ type properties struct {
 	props map[string]any
 }
 
-func newProperties(props map[string]any, res []string) properties {
-	p := properties{props: map[string]any{}}
-	for k, v := range props {
-		if isReserved(res, k) {
-			continue
-		}
-		p.props[k] = v
-	}
-	return p
-}
-
-func isReserved(res []string, k string) bool {
-	for _, r := range res {
-		if k == r {
-			return true
-		}
-	}
-	return false
+func newProperties(props map[string]any) properties {
+	return properties{props: props}
 }
 
 // Prop gets a property from the schema.
@@ -484,7 +460,7 @@ func NewPrimitiveSchema(t Type, l LogicalSchema, opts ...SchemaOption) *Primitiv
 	}
 
 	return &PrimitiveSchema{
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		typ:                t,
 		logical:            l,
@@ -574,7 +550,7 @@ func NewRecordSchema(name, namespace string, fields []*Field, opts ...SchemaOpti
 
 	return &RecordSchema{
 		name:               n,
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		fields:             fields,
 		doc:                cfg.doc,
@@ -743,7 +719,7 @@ func NewField(name string, typ Schema, opts ...SchemaOption) (*Field, error) {
 	}
 
 	f := &Field{
-		properties: newProperties(cfg.props, fieldReserved),
+		properties: newProperties(cfg.props),
 		name:       name,
 		aliases:    cfg.aliases,
 		doc:        cfg.doc,
@@ -919,7 +895,7 @@ func NewEnumSchema(name, namespace string, symbols []string, opts ...SchemaOptio
 
 	return &EnumSchema{
 		name:               n,
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		symbols:            symbols,
 		def:                def,
@@ -1072,7 +1048,7 @@ func NewArraySchema(items Schema, opts ...SchemaOption) *ArraySchema {
 	}
 
 	return &ArraySchema{
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		items:              items,
 	}
@@ -1142,7 +1118,7 @@ func NewMapSchema(values Schema, opts ...SchemaOption) *MapSchema {
 	}
 
 	return &MapSchema{
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		values:             values,
 	}
@@ -1325,7 +1301,7 @@ func NewFixedSchema(
 
 	return &FixedSchema{
 		name:               n,
-		properties:         newProperties(cfg.props, schemaReserved),
+		properties:         newProperties(cfg.props),
 		cacheFingerprinter: cacheFingerprinter{writerFingerprint: cfg.wfp},
 		size:               size,
 		logical:            logical,

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -158,6 +158,7 @@ func parseComplexType(namespace string, m map[string]any, seen seenCache, cache 
 }
 
 type primitiveSchema struct {
+	Type        string         `mapstructure:"type"`
 	LogicalType string         `mapstructure:"logicalType"`
 	Precision   int            `mapstructure:"precision"`
 	Scale       int            `mapstructure:"scale"`
@@ -368,6 +369,7 @@ func parseEnum(namespace string, m map[string]any, seen seenCache, cache *Schema
 }
 
 type arraySchema struct {
+	Type  string         `mapstructure:"type"`
 	Items any            `mapstructure:"items"`
 	Props map[string]any `mapstructure:",remain"`
 }
@@ -393,6 +395,7 @@ func parseArray(namespace string, m map[string]any, seen seenCache, cache *Schem
 }
 
 type mapSchema struct {
+	Type   string         `mapstructure:"type"`
 	Values any            `mapstructure:"values"`
 	Props  map[string]any `mapstructure:",remain"`
 }


### PR DESCRIPTION
Parsing no longer necessitates having reservations when adding properties, further this allows users more freedom in what properties are stored, as long as they do not conflict with the current types fields.