### PR TITLE
Preserve unrecognized logical types and properties

### DIFF
--- a/gen/testdata/golden.avsc
+++ b/gen/testdata/golden.avsc
@@ -106,7 +106,6 @@
     {
       "name": "mapOfStrings",
       "type": {
-        "name": "aMapOfStrings",
         "type": "map",
         "values": "string"
       }
@@ -114,7 +113,6 @@
     {
       "name": "mapOfRecords",
       "type": {
-        "name": "aMapOfRecords",
         "type": "map",
         "values": {
           "name": "RecordInMap",
@@ -175,7 +173,6 @@
     {
       "name": "aRecordArray",
       "type": {
-        "name": "someRecordArray",
         "type": "array",
         "items": {
           "name": "recordInArray",

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -1074,6 +1074,7 @@ func TestWithSchemaMarshaler(t *testing.T) {
 				"name": "meta",
 				"type": {
 					"type": "array",
+					"logicalType": "map",
 					"items": {
 						"type": "record",
 						"name": "FooMetadataEntry",

--- a/ocf/testdata/full-schema.json
+++ b/ocf/testdata/full-schema.json
@@ -35,7 +35,8 @@
               "field-id": 5
             }
           ]
-        }
+        },
+        "logicalType": "map"
       },
       "field-id": 3
     }

--- a/schema.go
+++ b/schema.go
@@ -27,14 +27,16 @@ var nullDefault nullDefaultType = struct{}{}
 var (
 	// Note: order matches the order of properties as they are named in the spec.
 	// 	https://avro.apache.org/docs/1.12.0/specification
-	recordReserved                   = []string{"type", "name", "namespace", "doc", "aliases", "fields"}
-	fieldReserved                    = []string{"name", "doc", "type", "order", "aliases", "default"}
-	enumReserved                     = []string{"type", "name", "namespace", "aliases", "doc", "symbols", "default"}
-	arrayReserved                    = []string{"type", "items"}
-	mapReserved                      = []string{"type", "values"}
-	fixedReserved                    = []string{"type", "name", "namespace", "aliases", "size"}
-	fixedWithLogicalTypeReserved     = []string{"type", "name", "namespace", "aliases", "size", "logicalType"}
-	fixedWithDecimalTypeReserved     = []string{"type", "name", "namespace", "aliases", "size", "logicalType", "precision", "scale"}
+	recordReserved               = []string{"type", "name", "namespace", "doc", "aliases", "fields"}
+	fieldReserved                = []string{"name", "doc", "type", "order", "aliases", "default"}
+	enumReserved                 = []string{"type", "name", "namespace", "aliases", "doc", "symbols", "default"}
+	arrayReserved                = []string{"type", "items"}
+	mapReserved                  = []string{"type", "values"}
+	fixedReserved                = []string{"type", "name", "namespace", "aliases", "size"}
+	fixedWithLogicalTypeReserved = []string{"type", "name", "namespace", "aliases", "size", "logicalType"}
+	fixedWithDecimalTypeReserved = []string{
+		"type", "name", "namespace", "aliases", "size", "logicalType", "precision", "scale",
+	}
 	primitiveReserved                = []string{"type"}
 	primitiveWithLogicalTypeReserved = []string{"type", "logicalType"}
 	primitiveWithDecimalTypeReserved = []string{"type", "logicalType", "precision", "scale"}

--- a/schema_json_test.go
+++ b/schema_json_test.go
@@ -24,6 +24,10 @@ func TestSchema_JSON(t *testing.T) {
 			json:  `"null"`,
 		},
 		{
+			input: `{"type":"null","other":"foo"}`,
+			json:  `{"type":"null","other":"foo"}`,
+		},
+		{
 			input: `"boolean"`,
 			json:  `"boolean"`,
 		},

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -135,13 +135,7 @@ func parseComplexType(namespace string, m map[string]any, seen seenCache, cache 
 	typ := Type(str)
 
 	switch typ {
-	case Null:
-		// TODO: Per the spec, "null" is a primitive type so should be permitted to
-		//       have other properties/metadata.
-		//       	https://avro.apache.org/docs/1.12.0/specification/#primitive-types
-		return &NullSchema{}, nil
-
-	case String, Bytes, Int, Long, Float, Double, Boolean:
+	case String, Bytes, Int, Long, Float, Double, Boolean, Null:
 		return parsePrimitive(typ, m)
 
 	case Record, Error:
@@ -172,6 +166,9 @@ type primitiveSchema struct {
 
 func parsePrimitive(typ Type, m map[string]any) (Schema, error) {
 	if len(m) == 0 {
+		if typ == Null {
+			return &NullSchema{}, nil
+		}
 		return NewPrimitiveSchema(typ, nil), nil
 	}
 
@@ -191,6 +188,9 @@ func parsePrimitive(typ Type, m map[string]any) (Schema, error) {
 		}
 	}
 
+	if typ == Null {
+		return NewNullSchema(WithProps(p.Props)), nil
+	}
 	return NewPrimitiveSchema(typ, logical, WithProps(p.Props)), nil
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -1551,3 +1551,594 @@ func TestSchema_DereferencingRectifiesAlreadySeenSchema(t *testing.T) {
 	n := strings.Count(strSchema, `"name":"org.hamba.avro.test1"`)
 	assert.Equal(t, 1, n)
 }
+
+func TestParse_PreservesAllProperties(t *testing.T) {
+	testCases := []struct {
+		name   string
+		schema string
+		check  func(t *testing.T, schema avro.Schema)
+	}{
+		{
+			name: "record",
+			schema: `{
+				"type": "record",
+				"name": "SomeRecord",
+				"logicalType": "complex-number",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3],
+				"fields": [
+					{
+						"name": "r",
+						"type": "double"
+					},
+					{
+						"name": "i",
+						"type": "double"
+					}
+				]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.RecordSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "complex-number",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "array",
+			schema: `{
+				"type": "array",
+				"name": "SomeArray",
+				"logicalType": "complex-number",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3],
+				"items": "double"
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.ArraySchema)
+				assert.Equal(t, map[string]any{
+					"name":        "SomeArray",
+					"logicalType": "complex-number",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "map",
+			schema: `{
+				"type": "map",
+				"name": "SomeMap",
+				"logicalType": "weights",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3],
+				"values": "double"
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.MapSchema)
+				assert.Equal(t, map[string]any{
+					"name":        "SomeMap",
+					"logicalType": "weights",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "enum",
+			schema: `{
+				"type": "enum",
+				"name": "SomeEnum",
+				"logicalType": "status",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3],
+				"symbols": ["A", "B", "C"],
+				"default": "A"
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.EnumSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "status",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "fixed-no-logical-type",
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 16,
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"precision": "abc",
+					"scale":     "def",
+					"other":     []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "fixed-unknown-logical-type",
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 16,
+				"logicalType": "uuid",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "uuid",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "fixed-decimal-logical-type",
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 16,
+				"logicalType": "decimal",
+				"precision": 10,
+				"scale": 3,
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"other": []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+				assert.Equal(t, avro.Decimal, rec.Logical().Type())
+			},
+		},
+		{
+			name: "fixed-invalid-decimal-logical-type-bad-values", // scale is too high
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 16,
+				"logicalType": "decimal",
+				"precision": 10,
+				"scale": 20,
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "decimal",
+					"precision":   10.0,
+					"scale":       20.0,
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "fixed-invalid-decimal-logical-type-bad-type", // precision and scale aren't ints
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 16,
+				"logicalType": "decimal",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "decimal",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "fixed-duration-logical",
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 12,
+				"logicalType": "duration",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"precision": "abc",
+					"scale":     "def",
+					"other":     []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+				assert.Equal(t, avro.Duration, rec.Logical().Type())
+			},
+		},
+		{
+			name: "primitive-no-logical-type",
+			schema: `{
+				"type": "long",
+				"name": "SomeLong",
+				"size": 16,
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"name":      "SomeLong",
+					"size":      16.0,
+					"precision": "abc",
+					"scale":     "def",
+					"other":     []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "primitive-unknown-logical-type",
+			schema: `{
+				"type": "string",
+				"name": "SomeString",
+				"logicalType": "enum-name",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"name":        "SomeString",
+					"logicalType": "enum-name",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "primitive-date-logical-type",
+			schema: `{
+				"type": "int",
+				"logicalType": "date",
+				"precision": 10,
+				"scale": 3,
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"precision": 10.0,
+					"scale":     3.0,
+					"other":     []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+				assert.Equal(t, avro.Date, rec.Logical().Type())
+			},
+		},
+		{
+			name: "primitive-decimal-logical-type",
+			schema: `{
+				"type": "bytes",
+				"logicalType": "decimal",
+				"precision": 10,
+				"scale": 3,
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"other": []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+				assert.Equal(t, avro.Decimal, rec.Logical().Type())
+			},
+		},
+		{
+			name: "primitive-invalid-decimal-logical-type-bad-values", // scale is too high
+			schema: `{
+				"type": "bytes",
+				"logicalType": "decimal",
+				"precision": 10,
+				"scale": 20,
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "decimal",
+					"precision":   10.0,
+					"scale":       20.0,
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "primitive-invalid-decimal-logical-type-bad-type", // precision and scale aren't ints
+			schema: `{
+				"type": "bytes",
+				"logicalType": "decimal",
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": "decimal",
+					"precision":   "abc",
+					"scale":       "def",
+					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			schema, err := avro.Parse(testCase.schema)
+			require.NoError(t, err)
+			testCase.check(t, schema)
+		})
+	}
+}
+
+func TestNewSchema_IgnoresInvalidProperties(t *testing.T) {
+	t.Run("record", func(t *testing.T) {
+		rec, err := avro.NewRecordSchema("abc.def.Xyz", "", nil,
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"name":      123,
+				"namespace": "abc",
+				"doc":       "blah",
+				"fields":    []any{1, 2, 3},
+				"aliases":   "foo",
+				"type":      false,
+				// valid
+				"other":       true,
+				"logicalType": "baz",
+			}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"other":       true,
+			"logicalType": "baz",
+		}, rec.Props())
+	})
+	t.Run("enum", func(t *testing.T) {
+		rec, err := avro.NewEnumSchema("abc.def.Xyz", "", []string{"ABC"},
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"name":      123,
+				"namespace": "abc",
+				"doc":       "blah",
+				"symbols":   []any{1, 2, 3},
+				"aliases":   "foo",
+				"type":      false,
+				"default":   123.456,
+				// valid
+				"other":       true,
+				"logicalType": "baz",
+			}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"other":       true,
+			"logicalType": "baz",
+		}, rec.Props())
+	})
+	t.Run("fixed-no-logical-type", func(t *testing.T) {
+		rec, err := avro.NewFixedSchema("abc.def.Xyz", "", 10, nil,
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"name":      123,
+				"namespace": "abc",
+				"size":      []any{1, 2, 3},
+				"aliases":   "foo",
+				"type":      false,
+				// valid
+				"doc":         "blah",
+				"other":       true,
+				"logicalType": "baz",
+				"precision":   "abc",
+				"scale":       "def",
+			}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"doc":         "blah",
+			"other":       true,
+			"logicalType": "baz",
+			"precision":   "abc",
+			"scale":       "def",
+		}, rec.Props())
+	})
+	t.Run("fixed-logical-type", func(t *testing.T) {
+		rec, err := avro.NewFixedSchema("abc.def.Xyz", "", 10, avro.NewPrimitiveLogicalSchema(avro.Duration),
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"name":        123,
+				"namespace":   "abc",
+				"size":        []any{1, 2, 3},
+				"aliases":     "foo",
+				"type":        false,
+				"logicalType": "baz",
+				// valid
+				"doc":       "blah",
+				"other":     true,
+				"precision": "abc",
+				"scale":     "def",
+			}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"doc":       "blah",
+			"other":     true,
+			"precision": "abc",
+			"scale":     "def",
+		}, rec.Props())
+	})
+	t.Run("fixed-decimal-logical-type", func(t *testing.T) {
+		rec, err := avro.NewFixedSchema("abc.def.Xyz", "", 10, avro.NewDecimalLogicalSchema(10, 0),
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"name":        123,
+				"namespace":   "abc",
+				"size":        []any{1, 2, 3},
+				"aliases":     "foo",
+				"type":        false,
+				"logicalType": "baz",
+				"precision":   "abc",
+				"scale":       "def",
+				// valid
+				"doc":   "blah",
+				"other": true,
+			}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"doc":   "blah",
+			"other": true,
+		}, rec.Props())
+	})
+	t.Run("array", func(t *testing.T) {
+		rec := avro.NewArraySchema(avro.NewPrimitiveSchema(avro.String, nil),
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"items": []any{1, 2, 3},
+				"type":  false,
+				// valid
+				"name":        123,
+				"namespace":   "abc",
+				"doc":         "blah",
+				"aliases":     "foo",
+				"other":       true,
+				"logicalType": "baz",
+			}))
+		assert.Equal(t, map[string]any{
+			"name":        123,
+			"namespace":   "abc",
+			"doc":         "blah",
+			"aliases":     "foo",
+			"other":       true,
+			"logicalType": "baz",
+		}, rec.Props())
+	})
+	t.Run("map", func(t *testing.T) {
+		rec := avro.NewMapSchema(avro.NewPrimitiveSchema(avro.String, nil),
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"values": []any{1, 2, 3},
+				"type":   false,
+				// valid
+				"name":        123,
+				"namespace":   "abc",
+				"doc":         "blah",
+				"aliases":     "foo",
+				"other":       true,
+				"logicalType": "baz",
+			}))
+		assert.Equal(t, map[string]any{
+			"name":        123,
+			"namespace":   "abc",
+			"doc":         "blah",
+			"aliases":     "foo",
+			"other":       true,
+			"logicalType": "baz",
+		}, rec.Props())
+	})
+	t.Run("primitive-no-logical-type", func(t *testing.T) {
+		rec := avro.NewPrimitiveSchema(avro.Long, nil,
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"type": false,
+				// valid
+				"name":        123,
+				"namespace":   "abc",
+				"size":        []any{1, 2, 3},
+				"aliases":     "foo",
+				"doc":         "blah",
+				"other":       true,
+				"logicalType": "baz",
+				"precision":   "abc",
+				"scale":       "def",
+			}))
+		assert.Equal(t, map[string]any{
+			"name":        123,
+			"namespace":   "abc",
+			"size":        []any{1, 2, 3},
+			"aliases":     "foo",
+			"doc":         "blah",
+			"other":       true,
+			"logicalType": "baz",
+			"precision":   "abc",
+			"scale":       "def",
+		}, rec.Props())
+	})
+	t.Run("primitive-logical-type", func(t *testing.T) {
+		rec := avro.NewPrimitiveSchema(avro.Long, avro.NewPrimitiveLogicalSchema(avro.TimestampMicros),
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"type":        false,
+				"logicalType": "baz",
+				// valid
+				"name":      123,
+				"namespace": "abc",
+				"size":      []any{1, 2, 3},
+				"aliases":   "foo",
+				"doc":       "blah",
+				"other":     true,
+				"precision": "abc",
+				"scale":     "def",
+			}))
+		assert.Equal(t, map[string]any{
+			"name":      123,
+			"namespace": "abc",
+			"size":      []any{1, 2, 3},
+			"aliases":   "foo",
+			"doc":       "blah",
+			"other":     true,
+			"precision": "abc",
+			"scale":     "def",
+		}, rec.Props())
+	})
+	t.Run("primitive-decimal-logical-type", func(t *testing.T) {
+		rec := avro.NewPrimitiveSchema(avro.Bytes, avro.NewDecimalLogicalSchema(10, 0),
+			avro.WithProps(map[string]any{
+				// invalid (conflict with other type properties)
+				"type":        false,
+				"logicalType": "baz",
+				"precision":   "abc",
+				"scale":       "def",
+				// valid
+				"name":      123,
+				"namespace": "abc",
+				"size":      []any{1, 2, 3},
+				"aliases":   "foo",
+				"doc":       "blah",
+				"other":     true,
+			}))
+		assert.Equal(t, map[string]any{
+			"name":      123,
+			"namespace": "abc",
+			"size":      []any{1, 2, 3},
+			"aliases":   "foo",
+			"doc":       "blah",
+			"other":     true,
+		}, rec.Props())
+	})
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1696,6 +1696,30 @@ func TestParse_PreservesAllProperties(t *testing.T) {
 			},
 		},
 		{
+			name: "fixed-invalid-logical-type",
+			schema: `{
+				"type": "fixed",
+				"name": "SomeFixed",
+				"size": 16,
+				"logicalType": {"foo": "bar", "baz": ["x","y","z"]},
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.FixedSchema)
+				assert.Equal(t, map[string]any{
+					"logicalType": map[string]any{
+						"foo": "bar",
+						"baz": []any{"x", "y", "z"},
+					},
+					"precision": "abc",
+					"scale":     "def",
+					"other":     []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
 			name: "fixed-decimal-logical-type",
 			schema: `{
 				"type": "fixed",
@@ -1816,6 +1840,30 @@ func TestParse_PreservesAllProperties(t *testing.T) {
 					"precision":   "abc",
 					"scale":       "def",
 					"other":       []any{1.0, 2.0, 3.0},
+				}, rec.Props())
+			},
+		},
+		{
+			name: "primitive-invalid-logical-type",
+			schema: `{
+				"type": "string",
+				"name": "SomeString",
+				"logicalType": {"foo": "bar", "baz": ["x","y","z"]},
+				"precision": "abc",
+				"scale": "def",
+				"other": [1,2,3]
+			}`,
+			check: func(t *testing.T, schema avro.Schema) {
+				rec := schema.(*avro.PrimitiveSchema)
+				assert.Equal(t, map[string]any{
+					"name": "SomeString",
+					"logicalType": map[string]any{
+						"foo": "bar",
+						"baz": []any{"x", "y", "z"},
+					},
+					"precision": "abc",
+					"scale":     "def",
+					"other":     []any{1.0, 2.0, 3.0},
 				}, rec.Props())
 			},
 		},


### PR DESCRIPTION
This updates the parsing of schema JSON documents and the way properties are possibly discarded (to avoid problematic properties that conflict with proper fields of a type and could result in invalid JSON if included when marshaling to JSON).

The tests now demonstrate that all properties and logical types are preserved as extra properties, even for unrecognized and incorrectly configured logical types, even for null types.

> Just a note, in the parser, it should not be needed to add LogicalType where it does not naturally exist, and it will be added to Props as part of the `,remain`.

I added these everywhere so that this property would be properly type-checked: if it is present, it should be a string. So now this will surface as an error if it's not a string, even for an "array" or "record" type.

Resolves #435.