### PR TITLE
feat: add CRC64-AVRO-LE fingerprint type

### DIFF
--- a/pkg/crc64/crc64.go
+++ b/pkg/crc64/crc64.go
@@ -86,7 +86,7 @@ func (d *digest) Sum(in []byte) []byte {
 	return append(in, byte(s>>56), byte(s>>48), byte(s>>40), byte(s>>32), byte(s>>24), byte(s>>16), byte(s>>8), byte(s))
 }
 
-// Sum returns the MD5 checksum of the data.
+// Sum returns the CRC64 checksum of the data, in big-endian byte order.
 func Sum(data []byte) [Size]byte {
 	d := digest{crc: Empty, tab: crc64Table}
 	d.Reset()
@@ -94,4 +94,21 @@ func Sum(data []byte) [Size]byte {
 	s := d.Sum64()
 	//nolint:lll
 	return [Size]byte{byte(s >> 56), byte(s >> 48), byte(s >> 40), byte(s >> 32), byte(s >> 24), byte(s >> 16), byte(s >> 8), byte(s)}
+}
+
+// SumLittleEndian returns the CRC64 checksum of the data, in little-endian byte order.
+func SumLittleEndian(data []byte) [Size]byte {
+	d := digest{crc: Empty, tab: crc64Table}
+	_, _ = d.Write(data)
+	s := d.Sum64()
+	return [Size]byte{
+		byte(s),
+		byte(s >> 8),
+		byte(s >> 16),
+		byte(s >> 24),
+		byte(s >> 32),
+		byte(s >> 40),
+		byte(s >> 48),
+		byte(s >> 56),
+	}
 }

--- a/pkg/crc64/crc64_test.go
+++ b/pkg/crc64/crc64_test.go
@@ -82,6 +82,60 @@ func TestDigest_BlockSize(t *testing.T) {
 	assert.Equal(t, 1, hash.BlockSize())
 }
 
+func TestGoldenSum(t *testing.T) {
+	tests := []struct {
+		in  string
+		out []byte
+	}{
+		{
+			in:  `"null"`,
+			out: []byte{0x63, 0xdd, 0x24, 0xe7, 0xcc, 0x25, 0x8f, 0x8a},
+		},
+		{
+			in:  `{"name":"foo","type":"fixed","size":15}`,
+			out: []byte{0x18, 0x60, 0x2e, 0xc3, 0xed, 0x31, 0xa5, 0x04},
+		},
+		{
+			in:  `{"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean"}]}`,
+			out: []byte{0x6c, 0xd8, 0xea, 0xf1, 0xc9, 0x68, 0xa3, 0x3b},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := Sum([]byte(test.in))
+			assert.Equal(t, test.out, got[:])
+		})
+	}
+}
+
+func TestGoldenSumLittleEndian(t *testing.T) {
+	tests := []struct {
+		in  string
+		out []byte
+	}{
+		{
+			in:  `"null"`,
+			out: []byte{0x8a, 0x8f, 0x25, 0xcc, 0xe7, 0x24, 0xdd, 0x63},
+		},
+		{
+			in:  `{"name":"foo","type":"fixed","size":15}`,
+			out: []byte{0x04, 0xa5, 0x31, 0xed, 0xc3, 0x2e, 0x60, 0x18},
+		},
+		{
+			in:  `{"name":"foo","type":"record","fields":[{"name":"f1","type":"boolean"}]}`,
+			out: []byte{0x3b, 0xa3, 0x68, 0xc9, 0xf1, 0xea, 0xd8, 0x6c},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			got := SumLittleEndian([]byte(test.in))
+			assert.Equal(t, test.out, got[:])
+		})
+	}
+}
+
 func bench(b *testing.B, size int64) {
 	b.SetBytes(size)
 
@@ -113,5 +167,27 @@ func BenchmarkCrc64(b *testing.B) {
 	})
 	b.Run("1KB", func(b *testing.B) {
 		bench(b, 1<<10)
+	})
+}
+
+func BenchmarkSum(b *testing.B) {
+	data := make([]byte, 4<<10)
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	b.Run("BigEndian", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = Sum(data)
+		}
+	})
+	b.Run("LittleEndian", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = SumLittleEndian(data)
+		}
 	})
 }

--- a/schema.go
+++ b/schema.go
@@ -106,9 +106,10 @@ type FingerprintType string
 
 // Fingerprint type constants.
 const (
-	CRC64Avro FingerprintType = "CRC64-AVRO"
-	MD5       FingerprintType = "MD5"
-	SHA256    FingerprintType = "SHA256"
+	CRC64Avro   FingerprintType = "CRC64-AVRO"
+	CRC64AvroLE FingerprintType = "CRC64-AVRO-LE"
+	MD5         FingerprintType = "MD5"
+	SHA256      FingerprintType = "SHA256"
 )
 
 // SchemaCache is a cache of schemas.
@@ -305,6 +306,9 @@ func (f *fingerprinter) FingerprintUsing(typ FingerprintType, stringer fmt.Strin
 	switch typ {
 	case CRC64Avro:
 		h := crc64.Sum(data)
+		fingerprint = h[:]
+	case CRC64AvroLE:
+		h := crc64.SumLittleEndian(data)
 		fingerprint = h[:]
 	case MD5:
 		h := md5.Sum(data)

--- a/schema_test.go
+++ b/schema_test.go
@@ -1217,6 +1217,12 @@ func TestSchema_FingerprintUsing(t *testing.T) {
 			want:   []byte{0x63, 0xdd, 0x24, 0xe7, 0xcc, 0x25, 0x8f, 0x8a},
 		},
 		{
+			name:   "Null CRC64LE",
+			schema: "null",
+			typ:    avro.CRC64AvroLE,
+			want:   []byte{0x8a, 0x8f, 0x25, 0xcc, 0xe7, 0x24, 0xdd, 0x63},
+		},
+		{
 			name:   "Null MD5",
 			schema: "null",
 			typ:    avro.MD5,


### PR DESCRIPTION
The Avro specification details a Single Object Encoding using a header to associate a schema ID with an Avro payload. The ID is defined as the CRC64 fingerprint in little-endian encoding.

The pkg/crc64 module only provides big-endian CRC64, and the CRC64-AVRO fingerprint type is implemented as such. The specification does not detail endianness of the CRC64-AVRO fingerprint itself (only when embedded in an SOE header).

To avoid breaking existing CRC64-AVRO fingerprints, add a new fingerprint type CRC64-AVRO-LE, identical to CRC64-AVRO except little-endian.

Add an additional crc64.SumLittleEndian function to distrurb existing code as little as possible.

Add tests and benchmarks for the Sum functions.

Fixes #489.