### PR TITLE
feat: add CRC64-AVRO-LE fingerprint type

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -106,9 +106,10 @@ type FingerprintType string
 
 // Fingerprint type constants.
 const (
-	CRC64Avro FingerprintType = "CRC64-AVRO"
-	MD5       FingerprintType = "MD5"
-	SHA256    FingerprintType = "SHA256"
+	CRC64Avro   FingerprintType = "CRC64-AVRO"
+	CRC64AvroLE FingerprintType = "CRC64-AVRO-LE"
+	MD5         FingerprintType = "MD5"
+	SHA256      FingerprintType = "SHA256"
 )
 
 // SchemaCache is a cache of schemas.
@@ -305,6 +306,9 @@ func (f *fingerprinter) FingerprintUsing(typ FingerprintType, stringer fmt.Strin
 	switch typ {
 	case CRC64Avro:
 		h := crc64.Sum(data)
+		fingerprint = h[:]
+	case CRC64AvroLE:
+		h := crc64.SumWithByteOrder(data, crc64.LittleEndian)
 		fingerprint = h[:]
 	case MD5:
 		h := md5.Sum(data)

--- a/schema_test.go
+++ b/schema_test.go
@@ -1217,6 +1217,12 @@ func TestSchema_FingerprintUsing(t *testing.T) {
 			want:   []byte{0x63, 0xdd, 0x24, 0xe7, 0xcc, 0x25, 0x8f, 0x8a},
 		},
 		{
+			name:   "Null CRC64-AVRO-LE",
+			schema: "null",
+			typ:    avro.CRC64AvroLE,
+			want:   []byte{0x8a, 0x8f, 0x25, 0xcc, 0xe7, 0x24, 0xdd, 0x63},
+		},
+		{
 			name:   "Null MD5",
 			schema: "null",
 			typ:    avro.MD5,


### PR DESCRIPTION
The Avro specification details a Single Object Encoding using a header
to associate a schema ID with an Avro payload. The ID is defined as the
CRC64 fingerprint in little-endian encoding.

The pkg/crc64 module only provides big-endian CRC64, and the CRC64-AVRO
fingerprint type is implemented as such. The specification does not
detail endianness of the CRC64-AVRO fingerprint itself (only when
embedded in an SOE header).

To avoid breaking existing CRC64-AVRO fingerprints, add a new
fingerprint type CRC64-AVRO-LE, identical to CRC64-AVRO except
little-endian.

Add NewWithByteOrder and SumWithByteOrder top-level functions to crc64
so users can configure the hasher to use a specific byte order.

Add tests and benchmarks for the SumWithByteOrder function.

Fixes #489.