### PR TITLE
fix: add handling to skip block data in Decoder readBlock method

### DIFF
--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -187,7 +187,8 @@ func (d *Decoder) readBlock() int64 {
 	size := d.reader.ReadLong()
 
 	// Read the blocks data
-	if count > 0 {
+	switch {
+	case count > 0:
 		data := make([]byte, size)
 		d.reader.Read(data)
 
@@ -197,8 +198,9 @@ func (d *Decoder) readBlock() int64 {
 		}
 
 		d.resetReader.Reset(data)
-	} else if size > 0 {
-		// Skip the block data
+
+	case size > 0:
+		// Skip the block data when count is 0
 		data := make([]byte, size)
 		d.reader.Read(data)
 	}

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -197,6 +197,10 @@ func (d *Decoder) readBlock() int64 {
 		}
 
 		d.resetReader.Reset(data)
+	} else if size > 0 {
+		// Skip the block data
+		data := make([]byte, size)
+		d.reader.Read(data)
 	}
 
 	// Read the sync.


### PR DESCRIPTION
Issue is with files having no data (file attached in zip)
File is from Google Cloud Platform. 

[empty_set.zip](https://github.com/user-attachments/files/18522805/empty_set.zip)
