### PR TITLE
fix panic concurrent parse

### DIFF
--- a/concurrent_parse_test.go
+++ b/concurrent_parse_test.go
@@ -10,9 +10,8 @@ import (
 
 func TestConcurrentParse(t *testing.T) {
 	var wg sync.WaitGroup
-	const numThreads = 50000
 
-	for i := 0; i < numThreads; i++ {
+	for i := 0; i < 50000; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/concurrent_parse_test.go
+++ b/concurrent_parse_test.go
@@ -1,0 +1,25 @@
+package avro_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hamba/avro/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentParse(t *testing.T) {
+	var wg sync.WaitGroup
+	const numThreads = 50000
+
+	for i := 0; i < numThreads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := avro.Parse(`{ "type": "record", "name": "Envelope", "namespace": "changefeed.pg.testtenant_teststore_abc_kv.public.kvs", "fields": [ { "name": "before", "type": [ "null", { "type": "record", "name": "Value", "fields": [ { "name": "tenant", "type": "string" }, { "name": "store", "type": "string" }, { "name": "partition_key", "type": "string" }, { "name": "sort_key", "type": "string" }, { "name": "version", "type": "string" }, { "name": "updated_at", "type": { "type": "string", "connect.version": 1, "connect.name": "io.debezium.time.ZonedTimestamp" } }, { "name": "tags", "type": [ "null", { "type": "array", "items": [ "null", "string" ] } ], "default": null }, { "name": "data", "type": [ "null", "string" ], "default": null }, { "name": "encoding", "type": [ "null", "string" ], "default": null }, { "name": "schema", "type": [ "null", "long" ], "default": null }, { "name": "lookup_keys", "type": [ "null", { "type": "array", "items": [ "null", "string" ] } ], "default": null } ], "connect.name": "changefeed.pg.testtenant_teststore_abc_kv.public.kvs.Value" } ], "default": null }, { "name": "after", "type": [ "null", "Value" ], "default": null }, { "name": "source", "type": { "type": "record", "name": "Source", "namespace": "io.debezium.connector.postgresql", "fields": [ { "name": "version", "type": "string" }, { "name": "connector", "type": "string" }, { "name": "name", "type": "string" }, { "name": "ts_ms", "type": "long" }, { "name": "snapshot", "type": [ { "type": "string", "connect.version": 1, "connect.parameters": { "allowed": "true,last,false,incremental" }, "connect.default": "false", "connect.name": "io.debezium.data.Enum" }, "null" ], "default": "false" }, { "name": "db", "type": "string" }, { "name": "sequence", "type": [ "null", "string" ], "default": null }, { "name": "ts_us", "type": [ "null", "long" ], "default": null }, { "name": "ts_ns", "type": [ "null", "long" ], "default": null }, { "name": "schema", "type": "string" }, { "name": "table", "type": "string" }, { "name": "txId", "type": [ "null", "long" ], "default": null }, { "name": "lsn", "type": [ "null", "long" ], "default": null }, { "name": "xmin", "type": [ "null", "long" ], "default": null } ], "connect.name": "io.debezium.connector.postgresql.Source" } }, { "name": "transaction", "type": [ "null", { "type": "record", "name": "block", "namespace": "event", "fields": [ { "name": "id", "type": "string" }, { "name": "total_order", "type": "long" }, { "name": "data_collection_order", "type": "long" } ], "connect.version": 1, "connect.name": "event.block" } ], "default": null }, { "name": "op", "type": "string" }, { "name": "ts_ms", "type": [ "null", "long" ], "default": null }, { "name": "ts_us", "type": [ "null", "long" ], "default": null }, { "name": "ts_ns", "type": [ "null", "long" ], "default": null } ], "connect.version": 2, "connect.name": "changefeed.pg.testtenant_teststore_abc_kv.public.kvs.Envelope" }`)
+			require.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/schema_parse.go
+++ b/schema_parse.go
@@ -64,7 +64,17 @@ func ParseFiles(paths ...string) (Schema, error) {
 
 // ParseBytes parses a schema byte slice.
 func ParseBytes(schema []byte) (Schema, error) {
-	return ParseBytesWithCache(schema, "", DefaultSchemaCache)
+	var internalCache = &SchemaCache{}
+	DefaultSchemaCache.cache.Range(func(key, value any) bool {
+		internalCache.Add(key.(string), value.(Schema))
+		return true
+	})
+	s, err := ParseBytesWithCache(schema, "", internalCache)
+	internalCache.cache.Range(func(key, value any) bool {
+		DefaultSchemaCache.Add(key.(string), value.(Schema))
+		return true
+	})
+	return s, err
 }
 
 // ParseBytesWithCache parses a schema byte slice using the given namespace and schema cache.


### PR DESCRIPTION
This pull request introduces a new test for concurrent parsing and modifies the schema parsing logic to use an internal cache. The most important changes include adding a new test file and updating the `ParseBytes` function to improve cache handling.

### New Test Addition:
* [`concurrent_parse_test.go`](diffhunk://#diff-16c19ec3114bc919dbb65c16e0e0ed30fe915f69d0c8148bb5a999ea7384c295R1-R25): Added a new test `TestConcurrentParse` to verify the concurrent parsing of schemas using multiple threads.

### Schema Parsing Improvements:
* [`schema_parse.go`](diffhunk://#diff-778f05933a6d581331989dcf1793cfca10bd80b5e0e3693ce8c146b26497c8efL67-R77): Modified the `ParseBytes` function to use an internal cache for schema parsing, ensuring thread safety and improving performance.