### PR TITLE
fix(gen): escape backticks

### DIFF
--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -100,6 +100,30 @@ func TestStruct_MultilineDoc(t *testing.T) {
 	}
 }
 
+func TestStruct_EscapeBacktick(t *testing.T) {
+	schema := `{
+  "type": "record",
+  "name": "Test",
+  "doc": "Test record doc with ` + "`" + `backticks` + "`" + `",
+  "fields": [
+    { "name": "someString", "type": "string" }
+  ]
+}`
+	gc := gen.Config{
+		PackageName: "Something",
+		Encoders:    true,
+		FullSchema:  true,
+	}
+
+	_, lines := generate(t, schema, gc)
+
+	for _, expected := range []string{
+		"var schemaTest = avro.MustParse(`{\"name\":\"Test\",\"doc\":\"Test record doc with ` + \"`\" + `backticks` + \"`\" + `\",\"type\":\"record\",\"fields\":[{\"name\":\"someString\",\"type\":\"string\"}]}`)",
+	} {
+		assert.Contains(t, lines, expected)
+	}
+}
+
 func TestStruct_HandlesAdditionalInitialisms(t *testing.T) {
 	schema := `{
   "type": "record",

--- a/gen/output_template.tmpl
+++ b/gen/output_template.tmpl
@@ -39,7 +39,7 @@ package {{ .PackageName }}
 	}
 
 	{{- if $encoders }}
-		var schema{{ .Name }} = avro.MustParse(`{{ .Schema }}`)
+		var schema{{ .Name }} = avro.MustParse(`{{ replace .Schema "`" "` + \"`\" + `" -1 }}`)
 
 		// Schema returns the schema for {{ .Name }}.
 		func (o *{{ .Name }}) Schema() avro.Schema {


### PR DESCRIPTION
There is a problem when generating Go code with encoders and full schema. If The schema has some backticks in doc string, then it will produce invalid Go code, because the schema JSON string is wrapped in backticks (``` ` ```). This needs backtick escaping.