### PR TITLE
fix: panic on null type

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -130,6 +130,8 @@ func decoderOfType(d *decoderContext, schema Schema, typ reflect2.Type) ValDecod
 	}
 
 	switch schema.Type() {
+	case Null:
+		return &nullCodec{}
 	case String, Bytes, Int, Long, Float, Double, Boolean:
 		return createDecoderOfNative(schema.(*PrimitiveSchema), typ)
 	case Record:
@@ -197,8 +199,10 @@ func encoderOfType(e *encoderContext, schema Schema, typ reflect2.Type) ValEncod
 	}
 
 	switch schema.Type() {
-	case String, Bytes, Int, Long, Float, Double, Boolean, Null:
-		return createEncoderOfNative(schema, typ)
+	case Null:
+		return &nullCodec{}
+	case String, Bytes, Int, Long, Float, Double, Boolean:
+		return createEncoderOfNative(schema.(*PrimitiveSchema), typ)
 	case Record:
 		key := cacheKey{fingerprint: schema.Fingerprint(), rtype: typ.RType()}
 		defEnc := &deferEncoder{}

--- a/codec.go
+++ b/codec.go
@@ -117,6 +117,7 @@ func newEncoderContext(cfg *frozenConfig) *encoderContext {
 	}
 }
 
+//nolint:dupl
 func decoderOfType(d *decoderContext, schema Schema, typ reflect2.Type) ValDecoder {
 	if dec := createDecoderOfMarshaler(schema, typ); dec != nil {
 		return dec
@@ -189,6 +190,7 @@ func (e *onePtrEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 	e.enc.Encode(noescape(unsafe.Pointer(&ptr)), w)
 }
 
+//nolint:dupl
 func encoderOfType(e *encoderContext, schema Schema, typ reflect2.Type) ValEncoder {
 	if enc := createEncoderOfMarshaler(schema, typ); enc != nil {
 		return enc

--- a/codec_generic.go
+++ b/codec_generic.go
@@ -39,6 +39,8 @@ func genericReceiver(schema Schema) (reflect2.Type, error) {
 	}
 
 	switch schema.Type() {
+	case Null:
+		return reflect2.TypeOf((*null)(nil)), nil
 	case Boolean:
 		var v bool
 		return reflect2.TypeOf(v), nil

--- a/codec_generic_internal_test.go
+++ b/codec_generic_internal_test.go
@@ -19,6 +19,13 @@ func TestGenericDecode(t *testing.T) {
 		wantErr require.ErrorAssertionFunc
 	}{
 		{
+			name:    "Null",
+			data:    []byte{},
+			schema:  "null",
+			want:    nil,
+			wantErr: require.NoError,
+		},
+		{
 			name:    "Bool",
 			data:    []byte{0x01},
 			schema:  "boolean",

--- a/codec_native.go
+++ b/codec_native.go
@@ -181,7 +181,7 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 }
 
 //nolint:maintidx // Splitting this would not make it simpler.
-func createEncoderOfNative(schema Schema, typ reflect2.Type) ValEncoder {
+func createEncoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValEncoder {
 	switch typ.Kind() {
 	case reflect.Bool:
 		if schema.Type() != Boolean {
@@ -323,10 +323,6 @@ func createEncoderOfNative(schema Schema, typ reflect2.Type) ValEncoder {
 		return &bytesDecimalPtrCodec{prec: dec.Precision(), scale: dec.Scale()}
 	}
 
-	if schema.Type() == Null {
-		return &nullCodec{}
-	}
-
 	return &errorEncoder{err: fmt.Errorf("avro: %s is unsupported for Avro %s", typ.String(), schema.Type())}
 }
 
@@ -349,6 +345,8 @@ func getLogicalType(schema Schema) LogicalType {
 }
 
 type nullCodec struct{}
+
+func (*nullCodec) Decode(unsafe.Pointer, *Reader) {}
 
 func (*nullCodec) Encode(unsafe.Pointer, *Writer) {}
 

--- a/decoder_record_test.go
+++ b/decoder_record_test.go
@@ -243,7 +243,8 @@ func TestDecoder_RecordMap(t *testing.T) {
 	"fields" : [
 		{"name": "a", "type": "long"},
 	    {"name": "b", "type": "string"},
-		{"name": "c", "type": ["null","string"]}
+		{"name": "c", "type": ["null","string"]},
+		{"name": "d", "type": "null"}
 	]
 }`
 	dec, err := avro.NewDecoder(schema, bytes.NewReader(data))
@@ -253,7 +254,7 @@ func TestDecoder_RecordMap(t *testing.T) {
 	err = dec.Decode(&got)
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]any{"a": int64(27), "b": "foo", "c": "foo"}, got)
+	assert.Equal(t, map[string]any{"a": int64(27), "b": "foo", "c": "foo", "d": nil}, got)
 }
 
 func TestDecoder_RecordMapInvalidKey(t *testing.T) {

--- a/encoder_record_test.go
+++ b/encoder_record_test.go
@@ -336,10 +336,11 @@ func TestEncoder_RecordMap(t *testing.T) {
 	"name": "test",
 	"fields" : [
 		{"name": "a", "type": "long"},
-	    {"name": "b", "type": "string"}
+	    {"name": "b", "type": "string"},
+		{"name": "c", "type": "null"}
 	]
 }`
-	obj := map[string]any{"a": int64(27), "b": "foo"}
+	obj := map[string]any{"a": int64(27), "b": "foo", "c": nil}
 	buf := &bytes.Buffer{}
 	enc, err := avro.NewEncoder(schema, buf)
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes an panic when a `Null` schema is encoded or decoded.

Fixes #432