### PR TITLE
chore: remove deprecated linter deadline

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
   tests: false
-  deadline: 5m
 
 linters-settings:
   gofumpt:


### PR DESCRIPTION
## Goal of this PR

This removes the deprecated `deadline` config for the linter.

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
