### PR TITLE
encoding/decoding improvements and fixes

### DIFF
--- a/codec_array.go
+++ b/codec_array.go
@@ -42,6 +42,10 @@ func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 	var size int
 	sliceType := d.typ
 
+	if sliceType.UnsafeIsNil(ptr) {
+		sliceType.UnsafeSet(ptr, sliceType.UnsafeMakeSlice(0, 0))
+	}
+
 	for {
 		l, _ := r.ReadBlockHeader()
 		if l == 0 {

--- a/codec_native.go
+++ b/codec_native.go
@@ -164,12 +164,12 @@ func createDecoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValDecode
 	case reflect.Ptr:
 		ptrType := typ.(*reflect2.UnsafePtrType)
 		elemType := ptrType.Elem()
-		tpy1 := elemType.Type1()
+		typ1 := elemType.Type1()
 		ls := getLogicalSchema(schema)
 		if ls == nil {
 			break
 		}
-		if !tpy1.ConvertibleTo(ratType) || schema.Type() != Bytes || ls.Type() != Decimal {
+		if !typ1.ConvertibleTo(ratType) || schema.Type() != Bytes || ls.Type() != Decimal {
 			break
 		}
 		dec := ls.(*DecimalLogicalSchema)
@@ -318,12 +318,12 @@ func createEncoderOfNative(schema *PrimitiveSchema, typ reflect2.Type) ValEncode
 	case reflect.Ptr:
 		ptrType := typ.(*reflect2.UnsafePtrType)
 		elemType := ptrType.Elem()
-		tpy1 := elemType.Type1()
+		typ1 := elemType.Type1()
 		ls := getLogicalSchema(schema)
 		if ls == nil {
 			break
 		}
-		if !tpy1.ConvertibleTo(ratType) || schema.Type() != Bytes || ls.Type() != Decimal {
+		if !typ1.ConvertibleTo(ratType) || schema.Type() != Bytes || ls.Type() != Decimal {
 			break
 		}
 		dec := ls.(*DecimalLogicalSchema)

--- a/codec_union.go
+++ b/codec_union.go
@@ -155,6 +155,12 @@ func (e *mapUnionEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 		return
 	}
 
+	// encode a nil array as an empty array
+	if schema.Type() == Array && val == nil {
+		// element data type doesn't matter since it won't even look at the array contents
+		val = []struct{}{}
+	}
+
 	elemType := reflect2.TypeOf(val)
 	elemPtr := reflect2.PtrOf(val)
 
@@ -366,11 +372,11 @@ func (d *unionResolvedDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 	switch typ.Kind() {
 	case reflect.Map:
 		mapType := typ.(*reflect2.UnsafeMapType)
-		newPtr = mapType.UnsafeMakeMap(1)
+		newPtr = mapType.UnsafeMakeMap(0)
 
 	case reflect.Slice:
 		mapType := typ.(*reflect2.UnsafeSliceType)
-		newPtr = mapType.UnsafeMakeSlice(1, 1)
+		newPtr = mapType.UnsafeMakeSlice(0, 0)
 
 	case reflect.Ptr:
 		elemType := typ.(*reflect2.UnsafePtrType).Elem()

--- a/config.go
+++ b/config.go
@@ -109,7 +109,7 @@ type API interface {
 	DecoderOf(schema Schema, typ reflect2.Type) ValDecoder
 
 	// EncoderOf returns the value encoder for a given schema and type.
-	EncoderOf(schema Schema, tpy reflect2.Type) ValEncoder
+	EncoderOf(schema Schema, typ reflect2.Type) ValEncoder
 
 	// Register registers names to their types for resolution. All primitive types are pre-registered.
 	Register(name string, obj any)

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -96,7 +96,7 @@ func TestDecoder_ArrayRecursiveStruct(t *testing.T) {
 	err := dec.Decode(&got)
 
 	assert.NoError(t, err)
-	assert.Equal(t, record{A: 1, B: []record{{A: 2}, {A: 3}}}, got)
+	assert.Equal(t, record{A: 1, B: []record{{A: 2, B: []record{}}, {A: 3, B: []record{}}}}, got)
 }
 
 func TestDecoder_ArraySliceError(t *testing.T) {

--- a/encoder_fixed_test.go
+++ b/encoder_fixed_test.go
@@ -94,6 +94,61 @@ func TestEncoder_FixedRatInvalidLogicalSchema(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEncoder_FixedString_Positive(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"fixed", "name": "test", "size": 6,"logicalType":"decimal","precision":4,"scale":2}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode("346.8")
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x87, 0x78}, buf.Bytes())
+}
+
+func TestEncoder_FixedString_Negative(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"fixed", "name": "test", "size": 6, "logicalType":"decimal","precision":4,"scale":2}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode("-346.8")
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x78, 0x88}, buf.Bytes())
+}
+
+func TestEncoder_FixedString_Zero(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"fixed", "name": "test", "size": 6,"logicalType":"decimal","precision":4,"scale":2}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode("0")
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_FixedString_Invalid(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `{"type":"fixed", "name": "test", "size": 6,"logicalType":"decimal","precision":4,"scale":2}`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	err = enc.Encode("foo")
+
+	assert.Error(t, err)
+}
+
 func TestEncoder_FixedLogicalDuration(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/encoder_native_test.go
+++ b/encoder_native_test.go
@@ -2,6 +2,7 @@ package avro_test
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -63,6 +64,90 @@ func TestEncoder_Int(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0x36}, buf.Bytes())
+}
+
+func TestEncoder_IntFromFloat32(t *testing.T) {
+	t.Run("is integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "int"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float32(27))
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x36}, buf.Bytes())
+	})
+
+	t.Run("is not integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "int"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float32(1.15))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("is out of range", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "int"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float32(math.MaxInt32 + 1))
+
+		assert.Error(t, err)
+	})
+}
+
+func TestEncoder_IntFromFloat64(t *testing.T) {
+	t.Run("is integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "int"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float64(27))
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x36}, buf.Bytes())
+	})
+
+	t.Run("is not integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "int"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float64(1.15))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("is out of range", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "int"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float64(math.MaxInt32 + 1))
+
+		assert.Error(t, err)
+	})
 }
 
 func TestEncoder_IntInvalidSchema(t *testing.T) {
@@ -280,6 +365,90 @@ func TestEncoder_Int64FromInt(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0x80, 0x80, 0x80, 0x80, 0x10}, buf.Bytes())
+}
+
+func TestEncoder_Int64FromFloat32(t *testing.T) {
+	t.Run("is integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "long"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float32(27))
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x36}, buf.Bytes())
+	})
+
+	t.Run("is not integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "long"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float32(1.15))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("is out of range", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "long"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float32(math.MaxInt64 + 1))
+
+		assert.Error(t, err)
+	})
+}
+
+func TestEncoder_Int64FromFloat64(t *testing.T) {
+	t.Run("is integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "long"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float64(27))
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x36}, buf.Bytes())
+	})
+
+	t.Run("is not integer", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "long"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float64(1.15))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("is out of range", func(t *testing.T) {
+		defer ConfigTeardown()
+
+		schema := "long"
+		buf := bytes.NewBuffer([]byte{})
+		enc, err := avro.NewEncoder(schema, buf)
+		require.NoError(t, err)
+
+		err = enc.Encode(float64(math.MaxInt64 + 1))
+
+		assert.Error(t, err)
+	})
 }
 
 func TestEncoder_Int64InvalidSchema(t *testing.T) {

--- a/encoder_union_test.go
+++ b/encoder_union_test.go
@@ -383,6 +383,74 @@ func TestEncoder_UnionInterfaceArray(t *testing.T) {
 	assert.Equal(t, []byte{0x02, 0x01, 0x02, 0x36, 0x00}, buf.Bytes())
 }
 
+func TestEncoder_UnionInterfaceArrayEmpty(t *testing.T) {
+	defer ConfigTeardown()
+
+	avro.Register("array:int", []int{})
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = []int{}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionInterfaceUnregisteredArray(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = map[string]any{
+		"array": []int{27},
+	}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x01, 0x02, 0x36, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionInterfaceUnregisteredArrayEmpty(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = map[string]any{
+		"array": []int{},
+	}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionInterfaceUnregisteredArrayNull(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = map[string]any{
+		"array": nil,
+	}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00}, buf.Bytes())
+}
+
 func TestEncoder_UnionInterfaceNull(t *testing.T) {
 	defer ConfigTeardown()
 

--- a/resolver.go
+++ b/resolver.go
@@ -22,10 +22,14 @@ func NewTypeResolver() *TypeResolver {
 
 	// Register basic types
 	r.Register(string(Null), &null{})
+	r.Register(string(Int), float32(0))
+	r.Register(string(Int), float64(0))
 	r.Register(string(Int), int8(0))
 	r.Register(string(Int), int16(0))
 	r.Register(string(Int), int32(0))
 	r.Register(string(Int), int(0))
+	r.Register(string(Long), float32(0))
+	r.Register(string(Long), float64(0))
 	r.Register(string(Long), int(0))
 	r.Register(string(Long), int64(0))
 	r.Register(string(Float), float32(0))


### PR DESCRIPTION
## Goal of this PR

There are a few semi-related changes in this PR, enabling round-tripping from Avro to JSON and back via `map[string]any`.  I can split this into 2 or 3 separate PRs, if you prefer:

1. encode Go `float32`/`float64` to Avro `int`/`long`, if the value is compatible with the Avro data type; i.e. integer and within bounds
	* this is because when unmarshalling JSON to `map[string]any`, all numbers are unmarshalled as `float64`, so this enables encoding said map to Avro, following the Avro schema
	* added unit tests `TestEncoder_Int*FromFloat*`

2. encode Go `string` to Avro `fixed decimal`, if the value is a decimal
	* this is because when unmarshalling JSON to `map[string]any`, all `big.Rat`s are unmarshalled as `string`, so this enables encoding said map to Avro, following the Avro schema
	* added unit tests `TestEncoder_FixedString_*`

3. improve handling of nil/empty slices when encoding and decoding
	* in some instances, nil and empty slices were improperly handled
	* this PR makes decoding consistent and fixes an encoding panic
	* added a number of unit tests around this, notably:
		* `TestDecoder_UnionInterfaceArrayEmpty` -- empty array of ints in union decoded to `any` as a slice of int with 1 element instead of empty slice
		* `TestDecoder_UnionArrayRecordEmpty` -- empty array of records in union decoded to non-nil pointer to nil slice as nil slice instead of empty slice
		* `TestDecoder_UnionInterfaceArrayRecordEmpty` -- empty array of records in union decoded to `any` as a slice of records with 1 element instead of empty slice
		* `TestEncoder_UnionInterfaceUnregisteredArrayNull` -- encoding a nil array in `map[string]any` panicked instead of encoding an empty slice

## How did I test it?

I added a number of unit tests that fail before these fixes and pass after applying the fixes.
