### PR TITLE
fix: empty and nil slice handling

### DIFF
--- a/codec_array.go
+++ b/codec_array.go
@@ -42,6 +42,10 @@ func (d *arrayDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 	var size int
 	sliceType := d.typ
 
+	if sliceType.UnsafeIsNil(ptr) {
+		sliceType.UnsafeSet(ptr, sliceType.UnsafeMakeSlice(0, 0))
+	}
+
 	for {
 		l, _ := r.ReadBlockHeader()
 		if l == 0 {

--- a/codec_union.go
+++ b/codec_union.go
@@ -155,6 +155,12 @@ func (e *mapUnionEncoder) Encode(ptr unsafe.Pointer, w *Writer) {
 		return
 	}
 
+	// encode a nil slice as an empty array
+	if schema.Type() == Array && val == nil {
+		// element data type doesn't matter since it skips iterating the slice
+		val = []struct{}{}
+	}
+
 	elemType := reflect2.TypeOf(val)
 	elemPtr := reflect2.PtrOf(val)
 
@@ -366,11 +372,11 @@ func (d *unionResolvedDecoder) Decode(ptr unsafe.Pointer, r *Reader) {
 	switch typ.Kind() {
 	case reflect.Map:
 		mapType := typ.(*reflect2.UnsafeMapType)
-		newPtr = mapType.UnsafeMakeMap(1)
+		newPtr = mapType.UnsafeMakeMap(0)
 
 	case reflect.Slice:
 		mapType := typ.(*reflect2.UnsafeSliceType)
-		newPtr = mapType.UnsafeMakeSlice(1, 1)
+		newPtr = mapType.UnsafeMakeSlice(0, 0)
 
 	case reflect.Ptr:
 		elemType := typ.(*reflect2.UnsafePtrType).Elem()

--- a/decoder_array_test.go
+++ b/decoder_array_test.go
@@ -96,7 +96,7 @@ func TestDecoder_ArrayRecursiveStruct(t *testing.T) {
 	err := dec.Decode(&got)
 
 	assert.NoError(t, err)
-	assert.Equal(t, record{A: 1, B: []record{{A: 2}, {A: 3}}}, got)
+	assert.Equal(t, record{A: 1, B: []record{{A: 2, B: []record{}}, {A: 3, B: []record{}}}}, got)
 }
 
 func TestDecoder_ArraySliceError(t *testing.T) {

--- a/encoder_union_test.go
+++ b/encoder_union_test.go
@@ -383,6 +383,74 @@ func TestEncoder_UnionInterfaceArray(t *testing.T) {
 	assert.Equal(t, []byte{0x02, 0x01, 0x02, 0x36, 0x00}, buf.Bytes())
 }
 
+func TestEncoder_UnionInterfaceArrayEmpty(t *testing.T) {
+	defer ConfigTeardown()
+
+	avro.Register("array:int", []int{})
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = []int{}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionInterfaceUnregisteredArray(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = map[string]any{
+		"array": []int{27},
+	}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x01, 0x02, 0x36, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionInterfaceUnregisteredArrayEmpty(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = map[string]any{
+		"array": []int{},
+	}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00}, buf.Bytes())
+}
+
+func TestEncoder_UnionInterfaceUnregisteredArrayNull(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `["int", {"type": "array", "items": "int"}]`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	var val any = map[string]any{
+		"array": nil,
+	}
+	err = enc.Encode(val)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x00}, buf.Bytes())
+}
+
 func TestEncoder_UnionInterfaceNull(t *testing.T) {
 	defer ConfigTeardown()
 


### PR DESCRIPTION
## Goal of this PR

Fix handling of empty and nil slices.  There are scenarios where empty slices get turned into slices of 1 element, and where nil slices cause a panic.

This PR fixes these scenarios.

## How did I test it?

Added unit tests that demonstrate various scenarios, some of which fail before the fix and pass with the fix.
Notably:

* `TestDecoder_UnionInterfaceArrayEmpty`
  * empty array of ints in union decoded as a slice of int with 1 element instead of empty slice
* `TestDecoder_UnionArrayRecordEmpty`
  * empty array of records in union decoded to non-nil pointer to nil slice as nil slice instead of empty slice
* `TestDecoder_UnionInterfaceArrayRecordEmpty`
  * empty array of records in union decoded as a slice of records with 1 element instead of empty slice
* `TestEncoder_UnionInterfaceUnregisteredArrayNull`
  * encoding a nil array in `map[string]any` panicked instead of encoding an empty slice
