### PR TITLE
chore: bump golangci-lint to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         go-version: [ "1.23", "1.24" ]
     env:
-      GOLANGCI_LINT_VERSION: v1.63.4
+      GOLANGCI_LINT_VERSION: v2.0.1
 
     steps:
       - name: Install Go
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,23 @@
+version: "2"
 run:
   tests: false
 
-linters-settings:
-  gofumpt:
-    extra-rules: true
-  gosec:
-    excludes:
-      - G115
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
 
 linters:
-  enable-all: true
+  default: all
   disable:
-    - cyclop # duplicate of gocyclo
-    - exportloopref # deprecated
+    - cyclop    # duplicate of gocyclo
     - depguard
     - err113
     - exhaustive
@@ -36,13 +41,16 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
-
-issues:
-  exclude-use-default: false
-  exclude:
-    - 'package-comments: should have a package comment'
-    - 'G103: Use of unsafe calls should be audited'
-  exclude-rules:
-  - path: (schema|protocol)\.go
-    linters:
-      - gosec
+  settings:
+    gosec:
+      excludes:
+        - G115
+        - G103
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gosec
+        path: (schema|protocol)\.go
+      - path: (.+)\.go$
+        text: 'package-comments: should have a package comment'


### PR DESCRIPTION
## Goal of this PR

This bumps golangci-lint to v2

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
