### PR TITLE
feat(cli): add possibility to fetch latest schema from schema registry

### DIFF
--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -206,7 +206,7 @@ func parseInitialisms(raw string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	result := []string{}
+	var result []string
 	for _, initialism := range strings.Split(raw, ",") {
 		if initialism != strings.ToUpper(initialism) {
 			return nil, fmt.Errorf("initialism %q must be fully in upper case", initialism)
@@ -224,7 +224,7 @@ func loadTemplate(templateFileName string) ([]byte, error) {
 	return os.ReadFile(filepath.Clean(templateFileName))
 }
 
-func parseSubjectVersion(entry string) (string, string, error) {
+func splitParameterEntry(entry string) (string, string, error) {
 	parts := strings.Split(entry, ":")
 	if len(parts) != 2 {
 		return "", "", errors.New("entry must be of format subject:version")
@@ -239,7 +239,7 @@ func schemaFromRegistry(schemaRegistry, entry string) (avro.Schema, error) {
 		return nil, err
 	}
 
-	subject, version, err := parseSubjectVersion(entry)
+	subject, version, err := splitParameterEntry(entry)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -106,7 +106,7 @@ func realMain(args []string, stdout, stderr io.Writer) int {
 				return 2
 			}
 		default:
-			schema, err = fetchSchemaFromRegistry(cfg.SchemaRegistry, entry)
+			schema, err = schemaFromRegistry(cfg.SchemaRegistry, entry)
 			if err != nil {
 				_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
 				return 2
@@ -233,7 +233,7 @@ func parseSubjectVersion(entry string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func fetchSchemaFromRegistry(schemaRegistry string, entry string) (avro.Schema, error) {
+func schemaFromRegistry(schemaRegistry string, entry string) (avro.Schema, error) {
 	client, err := registry.NewClient(schemaRegistry)
 	if err != nil {
 		return nil, err

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -233,7 +233,7 @@ func parseSubjectVersion(entry string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func schemaFromRegistry(schemaRegistry string, entry string) (avro.Schema, error) {
+func schemaFromRegistry(schemaRegistry, entry string) (avro.Schema, error) {
 	client, err := registry.NewClient(schemaRegistry)
 	if err != nil {
 		return nil, err

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -206,7 +206,7 @@ func parseInitialisms(raw string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	var result []string
+	result := []string{}
 	for _, initialism := range strings.Split(raw, ",") {
 		if initialism != strings.ToUpper(initialism) {
 			return nil, fmt.Errorf("initialism %q must be fully in upper case", initialism)

--- a/cmd/avrogen/main.go
+++ b/cmd/avrogen/main.go
@@ -244,12 +244,8 @@ func schemaFromRegistry(schemaRegistry, entry string) (avro.Schema, error) {
 		return nil, err
 	}
 
-	if version != "latest" {
-		v, err := strconv.Atoi(version)
-		if err != nil {
-			return nil, err
-		}
-		schema, err := client.GetSchemaByVersion(context.Background(), subject, v)
+	if version == "latest" {
+		schema, err := client.GetLatestSchema(context.Background(), subject)
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +253,11 @@ func schemaFromRegistry(schemaRegistry, entry string) (avro.Schema, error) {
 		return schema, nil
 	}
 
-	schema, err := client.GetLatestSchema(context.Background(), subject)
+	v, err := strconv.Atoi(version)
+	if err != nil {
+		return nil, err
+	}
+	schema, err := client.GetSchemaByVersion(context.Background(), subject, v)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Goal of this PR

In case of struct generation from schema registry entries, we can pass not only numerical versions, but also a 'latest' version.

<!--
Fixes #
-->

## How did I test it?

Manual test with local schema registry.

```
/home/ekazakas/.cache/JetBrains/GoLand2024.3/tmp/GoLand/___go_build_github_com_hamba_avro_v2_cmd_avrogen -pkg test -schemaregistry http://localhost:8081 print_report:latest #gosetup
// Code generated by avro/gen. DO NOT EDIT.
package test

// PrintReport is a generated struct.
type PrintReport struct {
	ID   int    `avro:"id"`
	Ref  string `avro:"ref"`
	Flag int    `avro:"flag"`
}

Process finished with the exit code 0
```

```
/home/ekazakas/.cache/JetBrains/GoLand2024.3/tmp/GoLand/___go_build_github_com_hamba_avro_v2_cmd_avrogen -pkg test -schemaregistry http://localhost:8081 print_report:1 #gosetup
// Code generated by avro/gen. DO NOT EDIT.
package test

// PrintReport is a generated struct.
type PrintReport struct {
	ID   int    `avro:"id"`
	Ref  string `avro:"ref"`
	Flag int    `avro:"flag"`
}

Process finished with the exit code 0
```
