### PR TITLE
feat(registry): add schema metadata properties to schema info

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -82,9 +82,14 @@ type credentials struct {
 }
 
 type schemaInfoPayload struct {
-	Schema  string `json:"schema"`
-	ID      int    `json:"id"`
-	Version int    `json:"version"`
+	Schema   string         `json:"schema"`
+	ID       int            `json:"id"`
+	Version  int            `json:"version"`
+	Metadata schemaMetadata `json:"metadata"`
+}
+
+type schemaMetadata struct {
+	Properties map[string]string `json:"properties"`
 }
 
 // Parse converts the string schema registry response into a
@@ -93,6 +98,9 @@ func (s *schemaInfoPayload) Parse() (info SchemaInfo, err error) {
 	info = SchemaInfo{
 		ID:      s.ID,
 		Version: s.Version,
+		Metadata: SchemaMetadata{
+			Properties: s.Metadata.Properties,
+		},
 	}
 	info.Schema, err = avro.Parse(s.Schema)
 	return info, err
@@ -100,9 +108,15 @@ func (s *schemaInfoPayload) Parse() (info SchemaInfo, err error) {
 
 // SchemaInfo represents a schema and metadata information.
 type SchemaInfo struct {
-	Schema  avro.Schema
-	ID      int
-	Version int
+	Schema   avro.Schema
+	ID       int
+	Version  int
+	Metadata SchemaMetadata
+}
+
+// SchemaMetadata represents the schema metadata.
+type SchemaMetadata struct {
+	Properties map[string]string
 }
 
 var defaultClient = &http.Client{


### PR DESCRIPTION
## Goal of this PR

Confluent Schema Registry supports tags, metadata, and rules, which together support the concept of a [Data Contract](https://docs.confluent.io/platform/7.9/schema-registry/fundamentals/data-contracts.html).

This change adds support only for [metadata properties](https://docs.confluent.io/platform/7.9/schema-registry/fundamentals/data-contracts.html#metadata-properties) that may include arbitrary information about the schema, such as who created it:

```json
{
  "schema": "...",
  "metadata": {
    "properties": {
      "owner": "Bob Jones",
      "email": "bob@acme.com"
    }
  }
}
```

Properties may also include [major schema version](https://docs.confluent.io/platform/7.9/schema-registry/fundamentals/data-contracts.html#application-major-versioning) to highlight incompatible changes throughout the schema history:

```json
{
  "schema": "...",
  "metadata": {
    "properties": {
      "application.major.version": "2"
    }
  }
}
```

## How did I test it?

Added new test case.
