### PR TITLE
ParseFiles: avoid avoidable allocation

### DIFF
--- a/schema_parse.go
+++ b/schema_parse.go
@@ -53,7 +53,7 @@ func ParseFiles(paths ...string) (Schema, error) {
 			return nil, err
 		}
 
-		schema, err = Parse(string(s))
+		schema, err = ParseBytes(s)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This avoids a two unneeded copies of the input data, at least with the code as read (it's unclear if the compiler would optimize this away).

## Goal of this PR

Memory optimization (or at least better use of functionality that already exists).

## How did I test it?

`go test`
