### PR TITLE
fix: parse struct tag field name correctly

### DIFF
--- a/codec_record.go
+++ b/codec_record.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"unsafe"
 
 	"github.com/modern-go/reflect2"
@@ -493,7 +494,7 @@ func describeStruct(tagKey string, typ reflect2.Type) *structDescriptor {
 
 				fieldName := field.Name()
 				if tag, ok := field.Tag().Lookup(tagKey); ok {
-					fieldName = tag
+					fieldName, _, _ = strings.Cut(tag, ",")
 				}
 
 				fields = append(fields, &structField{


### PR DESCRIPTION
## Summary
- Fix struct tag parsing to handle comma-separated tag values correctly
- Parse only the field name portion before the first comma (e.g., `avro:"field_name,omitempty"` → field name is `field_name`)
- This follows Go's standard convention for struct tags

## Changes
- Added `strings.Cut()` to extract only the field name before the comma
- Previously the entire tag value including options was incorrectly used as the field name