### PR TITLE
feat(api): expose Name and Type functions of TypeResolver

### DIFF
--- a/config.go
+++ b/config.go
@@ -118,8 +118,10 @@ type API interface {
 	// RegisterTypeConverters registers type conversion functions.
 	RegisterTypeConverters(conv ...TypeConverter)
 
+	// TypeOf returns the schema type for a given name.
 	TypeOf(name string) (reflect2.Type, error)
 
+	// NamesOf returns the names associated with a given type.
 	NamesOf(typ reflect2.Type) ([]string, error)
 }
 


### PR DESCRIPTION
## Goal of this PR

Sometimes it can be useful to get the registered struct types from TypeResolver and instantiate empty structs for unmarshalling.

<!--
Fixes #
-->

## How did I test it?

Registering custom struct and then fetching it's type using modified library.
