### PR TITLE
chore: support Go 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ "1.23", "1.24" ]
+        go-version: [ "1.24", "1.25" ]
     env:
-      GOLANGCI_LINT_VERSION: v2.1.6
+      GOLANGCI_LINT_VERSION: v2.4.0
 
     steps:
       - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
       - name: Setup gotestsum
         uses: gertd/action-gotestsum@v3.0.0
         with:
-          gotestsum_version: v1.12.0
+          gotestsum_version: v1.13.0
 
       - name: Run Tests
         run: gotestsum --junitfile tests.xml --format pkgname -- -covermode=atomic -coverprofile=coverage.out -race ./...
@@ -105,7 +105,7 @@ jobs:
           - os: windows
             arch: s390x
     env:
-      GO_VERSION: "1.24"
+      GO_VERSION: "1.25"
 
     steps:
       - name: Checkout code

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,11 +37,13 @@ linters:
     - mnd
     - nestif
     - nlreturn
+    - noinlineerr
     - nonamedreturns
     - tagliatelle
     - varnamelen
     - wrapcheck
     - wsl
+    - wsl_v5
   settings:
     gosec:
       excludes:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hamba/avro/v2
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.24.0
 
 require (
 	github.com/ettle/strcase v0.2.0

--- a/schema.go
+++ b/schema.go
@@ -592,6 +592,7 @@ type RecordSchema struct {
 	properties
 	fingerprinter
 	cacheFingerprinter
+
 	isError bool
 	fields  []*Field
 	doc     string


### PR DESCRIPTION
## Goal of this PR

This bumps Go support to 1.24 and 1.25

<!--
Fixes #
-->

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
