### PR TITLE
Concurrent Decoder

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -31,6 +31,11 @@ func (e *Encoder) Encode(v any) error {
 	return e.w.Error
 }
 
+// Reset resets the encoder to write to a new io.Writer.
+func (e *Encoder) Reset(w io.Writer) {
+	e.w.Reset(w)
+}
+
 // Marshal returns the Avro encoding of v.
 func Marshal(schema Schema, v any) ([]byte, error) {
 	return DefaultConfig.Marshal(schema, v)

--- a/encoder.go
+++ b/encoder.go
@@ -31,11 +31,6 @@ func (e *Encoder) Encode(v any) error {
 	return e.w.Error
 }
 
-// Reset resets the encoder to write to a new io.Writer.
-func (e *Encoder) Reset(w io.Writer) {
-	e.w.Reset(w)
-}
-
 // Marshal returns the Avro encoding of v.
 func Marshal(schema Schema, v any) ([]byte, error) {
 	return DefaultConfig.Marshal(schema, v)

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -429,7 +429,7 @@ func newEncoder(schema avro.Schema, w io.Writer, cfg encoderConfig) (*Encoder, e
 				return nil, err
 			}
 
-			writer := avro.NewWriter(w, 512, avro.WithWriterConfig(cfg.EncodingConfig))
+			writer := avro.NewWriter(w, 512, avro.WithWriterConfig(avro.DefaultConfig))
 			buf := &bytes.Buffer{}
 			e := &Encoder{
 				writer:      writer,
@@ -470,7 +470,7 @@ func newEncoder(schema avro.Schema, w io.Writer, cfg encoderConfig) (*Encoder, e
 		return nil, err
 	}
 
-	writer := avro.NewWriter(w, 512, avro.WithWriterConfig(cfg.EncodingConfig))
+	writer := avro.NewWriter(w, 512, avro.WithWriterConfig(avro.DefaultConfig))
 	writer.WriteVal(HeaderSchema, header)
 	if err = writer.Flush(); err != nil {
 		return nil, err

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -381,9 +381,6 @@ type Encoder struct {
 	blockLength int
 	count       int
 	blockSize   int
-
-	// Stored for Reset.
-	header Header
 }
 
 // NewEncoder returns a new encoder that writes to w using schema s.
@@ -437,11 +434,6 @@ func newEncoder(schema avro.Schema, w io.Writer, cfg encoderConfig) (*Encoder, e
 				codec:       h.Codec,
 				blockLength: cfg.BlockLength,
 				blockSize:   cfg.BlockSize,
-				header: Header{
-					Magic: magicBytes,
-					Meta:  h.Meta,
-					Sync:  h.Sync,
-				},
 			}
 			return e, nil
 		}
@@ -483,7 +475,6 @@ func newEncoder(schema avro.Schema, w io.Writer, cfg encoderConfig) (*Encoder, e
 		codec:       codec,
 		blockLength: cfg.BlockLength,
 		blockSize:   cfg.BlockSize,
-		header:      header,
 	}
 	return e, nil
 }
@@ -570,34 +561,6 @@ func (e *Encoder) Close() error {
 		}
 	}
 	return err
-}
-
-// Reset flushes any pending data, resets the encoder to write to a new io.Writer,
-// and writes a fresh header with a new sync marker. The schema, codec, and other
-// settings are preserved from the original encoder.
-// This allows reusing the encoder for multiple files without reallocating buffers.
-func (e *Encoder) Reset(w io.Writer) error {
-	if err := e.Flush(); err != nil {
-		return err
-	}
-
-	// Generate new sync marker for the new file.
-	_, _ = rand.Read(e.header.Sync[:])
-	e.sync = e.header.Sync
-
-	// Reset writer to new output and write header.
-	e.writer.Reset(w)
-	e.writer.WriteVal(HeaderSchema, e.header)
-	if err := e.writer.Flush(); err != nil {
-		return err
-	}
-
-	// Reset buffer and encoder.
-	e.buf.Reset()
-	e.encoder.Reset(e.buf)
-	e.count = 0
-
-	return nil
 }
 
 func (e *Encoder) writerBlock() error {

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -138,7 +138,7 @@ func NewDecoder(r io.Reader, opts ...DecoderFunc) (*Decoder, error) {
 	}, nil
 }
 
-// NewDecoder returns a new decoder that reads from reader r.
+// NewDecoderWithHeader returns a new decoder that reads from reader r using the provided header.
 func NewDecoderWithHeader(r *avro.Reader, h *OCFHeader, opts ...DecoderFunc) (*Decoder, error) {
 	cfg := newDecoderConfig(opts...)
 	decReader := bytesx.NewResetReader([]byte{})
@@ -216,6 +216,7 @@ func (d *Decoder) Close() error {
 	return nil
 }
 
+// BlockStatus represents the status of the current block.
 type BlockStatus struct {
 	Current int64
 	Count   int64
@@ -223,6 +224,7 @@ type BlockStatus struct {
 	Offset  int64
 }
 
+// BlockStatus returns the current block status.
 func (d *Decoder) BlockStatus() *BlockStatus {
 	return &BlockStatus{
 		Current: d.n - d.count + 1,
@@ -615,7 +617,8 @@ func (e *Encoder) writerBlock() error {
 	return e.writer.Flush()
 }
 
-type OCFHeader struct {
+// OCFHeader represents the parsed header of an OCF file.
+type OCFHeader struct { //nolint:revive
 	Schema avro.Schema
 	Codec  Codec
 	Meta   map[string][]byte

--- a/ocf/ocf.go
+++ b/ocf/ocf.go
@@ -381,6 +381,9 @@ type Encoder struct {
 	blockLength int
 	count       int
 	blockSize   int
+
+	// Stored for Reset.
+	header Header
 }
 
 // NewEncoder returns a new encoder that writes to w using schema s.
@@ -434,6 +437,11 @@ func newEncoder(schema avro.Schema, w io.Writer, cfg encoderConfig) (*Encoder, e
 				codec:       h.Codec,
 				blockLength: cfg.BlockLength,
 				blockSize:   cfg.BlockSize,
+				header: Header{
+					Magic: magicBytes,
+					Meta:  h.Meta,
+					Sync:  h.Sync,
+				},
 			}
 			return e, nil
 		}
@@ -475,6 +483,7 @@ func newEncoder(schema avro.Schema, w io.Writer, cfg encoderConfig) (*Encoder, e
 		codec:       codec,
 		blockLength: cfg.BlockLength,
 		blockSize:   cfg.BlockSize,
+		header:      header,
 	}
 	return e, nil
 }
@@ -561,6 +570,34 @@ func (e *Encoder) Close() error {
 		}
 	}
 	return err
+}
+
+// Reset flushes any pending data, resets the encoder to write to a new io.Writer,
+// and writes a fresh header with a new sync marker. The schema, codec, and other
+// settings are preserved from the original encoder.
+// This allows reusing the encoder for multiple files without reallocating buffers.
+func (e *Encoder) Reset(w io.Writer) error {
+	if err := e.Flush(); err != nil {
+		return err
+	}
+
+	// Generate new sync marker for the new file.
+	_, _ = rand.Read(e.header.Sync[:])
+	e.sync = e.header.Sync
+
+	// Reset writer to new output and write header.
+	e.writer.Reset(w)
+	e.writer.WriteVal(HeaderSchema, e.header)
+	if err := e.writer.Flush(); err != nil {
+		return err
+	}
+
+	// Reset buffer and encoder.
+	e.buf.Reset()
+	e.encoder.Reset(e.buf)
+	e.count = 0
+
+	return nil
 }
 
 func (e *Encoder) writerBlock() error {

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -1347,7 +1347,7 @@ func TestConcurrentDecode(t *testing.T) {
 	require.NoError(t, err)
 
 	// concurrency values to test; caller requirement: configurable concurrency
-	concs := []int64{1}
+	concs := []int64{1, 2, 3, 5}
 
 	// split file into parts by size and let workers align to sync using SkipTo
 	headerEnd := r0.InputOffset()

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -1277,6 +1277,7 @@ func TestWithSchemaMarshaler(t *testing.T) {
 
 	want, err := os.ReadFile("testdata/full-schema.json")
 	require.NoError(t, err)
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
 	assert.Equal(t, want, got)
 }
 
@@ -1443,6 +1444,7 @@ func TestConcurrentDecode(t *testing.T) {
 		})
 	}
 }
+
 // TestEncoder_Reset tests that Reset allows reusing encoder for multiple files.
 func TestEncoder_Reset(t *testing.T) {
 	record1 := FullRecord{

--- a/ocf/ocf_test.go
+++ b/ocf/ocf_test.go
@@ -1443,3 +1443,265 @@ func TestConcurrentDecode(t *testing.T) {
 		})
 	}
 }
+// TestEncoder_Reset tests that Reset allows reusing encoder for multiple files.
+func TestEncoder_Reset(t *testing.T) {
+	record1 := FullRecord{
+		Strings: []string{"first", "record"},
+		Longs:   []int64{},
+		Enum:    "A",
+		Map:     map[string]int{},
+		Record:  &TestRecord{Long: 1},
+	}
+	record2 := FullRecord{
+		Strings: []string{"second", "record"},
+		Longs:   []int64{},
+		Enum:    "B",
+		Map:     map[string]int{},
+		Record:  &TestRecord{Long: 2},
+	}
+
+	// Create first file
+	buf1 := &bytes.Buffer{}
+	enc, err := ocf.NewEncoder(schema, buf1)
+	require.NoError(t, err)
+
+	err = enc.Encode(record1)
+	require.NoError(t, err)
+
+	err = enc.Close()
+	require.NoError(t, err)
+
+	// Reset to write to second file
+	buf2 := &bytes.Buffer{}
+	err = enc.Reset(buf2)
+	require.NoError(t, err)
+
+	err = enc.Encode(record2)
+	require.NoError(t, err)
+
+	err = enc.Close()
+	require.NoError(t, err)
+
+	// Verify first file
+	dec1, err := ocf.NewDecoder(buf1)
+	require.NoError(t, err)
+
+	require.True(t, dec1.HasNext())
+	var got1 FullRecord
+	err = dec1.Decode(&got1)
+	require.NoError(t, err)
+	assert.Equal(t, record1, got1)
+	require.False(t, dec1.HasNext())
+
+	// Verify second file
+	dec2, err := ocf.NewDecoder(buf2)
+	require.NoError(t, err)
+
+	require.True(t, dec2.HasNext())
+	var got2 FullRecord
+	err = dec2.Decode(&got2)
+	require.NoError(t, err)
+	assert.Equal(t, record2, got2)
+	require.False(t, dec2.HasNext())
+}
+
+// TestEncoder_ResetWithPendingData tests Reset flushes pending data.
+func TestEncoder_ResetWithPendingData(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	enc, err := ocf.NewEncoder(`"long"`, buf1, ocf.WithBlockLength(10))
+	require.NoError(t, err)
+
+	// Write data but don't close (pending data)
+	err = enc.Encode(int64(42))
+	require.NoError(t, err)
+
+	// Reset should flush the pending data
+	buf2 := &bytes.Buffer{}
+	err = enc.Reset(buf2)
+	require.NoError(t, err)
+
+	// Verify first file has the data
+	dec1, err := ocf.NewDecoder(buf1)
+	require.NoError(t, err)
+
+	require.True(t, dec1.HasNext())
+	var got int64
+	err = dec1.Decode(&got)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), got)
+}
+
+// TestEncoder_ResetGeneratesNewSyncMarker tests that each reset creates a new sync marker.
+func TestEncoder_ResetGeneratesNewSyncMarker(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	enc, err := ocf.NewEncoder(`"long"`, buf1)
+	require.NoError(t, err)
+
+	err = enc.Encode(int64(1))
+	require.NoError(t, err)
+	err = enc.Close()
+	require.NoError(t, err)
+
+	// Get sync marker from first file
+	dec1, err := ocf.NewDecoder(bytes.NewReader(buf1.Bytes()))
+	require.NoError(t, err)
+
+	reader1 := avro.NewReader(bytes.NewReader(buf1.Bytes()), 1024)
+	var h1 ocf.Header
+	reader1.ReadVal(ocf.HeaderSchema, &h1)
+	require.NoError(t, reader1.Error)
+	sync1 := h1.Sync
+
+	// Reset to second buffer
+	buf2 := &bytes.Buffer{}
+	err = enc.Reset(buf2)
+	require.NoError(t, err)
+
+	err = enc.Encode(int64(2))
+	require.NoError(t, err)
+	err = enc.Close()
+	require.NoError(t, err)
+
+	// Get sync marker from second file
+	reader2 := avro.NewReader(bytes.NewReader(buf2.Bytes()), 1024)
+	var h2 ocf.Header
+	reader2.ReadVal(ocf.HeaderSchema, &h2)
+	require.NoError(t, reader2.Error)
+	sync2 := h2.Sync
+
+	// Sync markers should be different
+	assert.NotEqual(t, sync1, sync2, "each file should have a unique sync marker")
+
+	// But both files should be readable
+	_ = dec1
+	dec2, err := ocf.NewDecoder(buf2)
+	require.NoError(t, err)
+	require.True(t, dec2.HasNext())
+}
+
+// TestEncoder_ResetMultipleTimes tests multiple sequential resets.
+func TestEncoder_ResetMultipleTimes(t *testing.T) {
+	buffers := make([]*bytes.Buffer, 5)
+	for i := range buffers {
+		buffers[i] = &bytes.Buffer{}
+	}
+
+	enc, err := ocf.NewEncoder(`"long"`, buffers[0])
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			err = enc.Reset(buffers[i])
+			require.NoError(t, err)
+		}
+
+		err = enc.Encode(int64(i * 10))
+		require.NoError(t, err)
+
+		err = enc.Close()
+		require.NoError(t, err)
+	}
+
+	// Verify all files
+	for i := 0; i < 5; i++ {
+		dec, err := ocf.NewDecoder(buffers[i])
+		require.NoError(t, err, "file %d", i)
+
+		require.True(t, dec.HasNext(), "file %d", i)
+		var got int64
+		err = dec.Decode(&got)
+		require.NoError(t, err, "file %d", i)
+		assert.Equal(t, int64(i*10), got, "file %d", i)
+	}
+}
+
+// TestEncoder_AppendToExistingFile tests appending records to an existing OCF file.
+func TestEncoder_AppendToExistingFile(t *testing.T) {
+	type SimpleRecord struct {
+		Name string `avro:"name"`
+		ID   int64  `avro:"id"`
+	}
+	simpleSchema := `{"type":"record","name":"SimpleRecord","fields":[{"name":"name","type":"string"},{"name":"id","type":"long"}]}`
+
+	record1 := SimpleRecord{Name: "first", ID: 1}
+	record2 := SimpleRecord{Name: "second", ID: 2}
+
+	tmpFile, err := os.CreateTemp("", "append-test-*.avro")
+	require.NoError(t, err)
+	tmpName := tmpFile.Name()
+	t.Cleanup(func() { _ = os.Remove(tmpName) })
+
+	// Write first record
+	enc, err := ocf.NewEncoder(simpleSchema, tmpFile)
+	require.NoError(t, err)
+	err = enc.Encode(record1)
+	require.NoError(t, err)
+	err = enc.Close()
+	require.NoError(t, err)
+	err = tmpFile.Close()
+	require.NoError(t, err)
+
+	// Reopen file and append second record
+	file, err := os.OpenFile(tmpName, os.O_RDWR, 0o644)
+	require.NoError(t, err)
+
+	enc2, err := ocf.NewEncoder(simpleSchema, file)
+	require.NoError(t, err)
+	err = enc2.Encode(record2)
+	require.NoError(t, err)
+	err = enc2.Close()
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+
+	// Read back and verify both records
+	file, err = os.Open(tmpName)
+	require.NoError(t, err)
+	defer file.Close()
+
+	dec, err := ocf.NewDecoder(file)
+	require.NoError(t, err)
+
+	var records []SimpleRecord
+	for dec.HasNext() {
+		var r SimpleRecord
+		err = dec.Decode(&r)
+		require.NoError(t, err)
+		records = append(records, r)
+	}
+	require.NoError(t, dec.Error())
+
+	require.Len(t, records, 2)
+	assert.Equal(t, record1, records[0])
+	assert.Equal(t, record2, records[1])
+}
+
+// TestEncoder_ResetPreservesCodec tests that codec is preserved across reset.
+func TestEncoder_ResetPreservesCodec(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	enc, err := ocf.NewEncoder(`"long"`, buf1, ocf.WithCodec(ocf.Deflate))
+	require.NoError(t, err)
+
+	err = enc.Encode(int64(1))
+	require.NoError(t, err)
+	err = enc.Close()
+	require.NoError(t, err)
+
+	buf2 := &bytes.Buffer{}
+	err = enc.Reset(buf2)
+	require.NoError(t, err)
+
+	err = enc.Encode(int64(2))
+	require.NoError(t, err)
+	err = enc.Close()
+	require.NoError(t, err)
+
+	// Both files should use deflate codec
+	dec1, err := ocf.NewDecoder(buf1)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("deflate"), dec1.Metadata()["avro.codec"])
+
+	dec2, err := ocf.NewDecoder(buf2)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("deflate"), dec2.Metadata()["avro.codec"])
+}

--- a/reader.go
+++ b/reader.go
@@ -31,6 +31,7 @@ type Reader struct {
 	buf    []byte
 	head   int
 	tail   int
+	offset int64
 	Error  error
 }
 
@@ -42,6 +43,7 @@ func NewReader(r io.Reader, bufSize int, opts ...ReaderFunc) *Reader {
 		buf:    make([]byte, bufSize),
 		head:   0,
 		tail:   0,
+		offset: 0,
 	}
 
 	for _, opt := range opts {
@@ -57,6 +59,8 @@ func (r *Reader) Reset(b []byte) *Reader {
 	r.buf = b
 	r.head = 0
 	r.tail = len(b)
+	r.offset = 0
+	r.Error = nil
 	return r
 }
 
@@ -90,6 +94,7 @@ func (r *Reader) loadMore() bool {
 			continue
 		}
 
+		r.offset += int64(r.tail)
 		r.head = 0
 		r.tail = n
 		return true
@@ -321,4 +326,9 @@ func (r *Reader) ReadBlockHeader() (int64, int64) {
 	}
 
 	return length, 0
+}
+
+// InputOffset returns the current input offset of the Reader.
+func (r *Reader) InputOffset() int64 {
+	return r.offset + int64(r.head)
 }

--- a/reader_skip.go
+++ b/reader_skip.go
@@ -99,10 +99,7 @@ func (r *Reader) SkipTo(token []byte) (int, error) {
 	for {
 		// Check boundary if we have stash from previous read
 		if len(stash) > 0 {
-			need := tokenLen - 1
-			if r.tail-r.head < need {
-				need = r.tail - r.head
-			}
+			need := min(r.tail-r.head, tokenLen-1)
 
 			// Construct boundary window: stash + beginning of new buffer
 			boundary := make([]byte, len(stash)+need)
@@ -136,10 +133,7 @@ func (r *Reader) SkipTo(token []byte) (int, error) {
 
 		// Prepare stash for next iteration
 		available := r.tail - r.head
-		keep := tokenLen - 1
-		if keep > available {
-			keep = available
-		}
+		keep := min(tokenLen-1, available)
 
 		// Bytes that are definitely skipped (not kept in stash)
 		consumed := available - keep

--- a/reader_skip_test.go
+++ b/reader_skip_test.go
@@ -9,6 +9,153 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestReader_SkipNBytes(t *testing.T) {
+	data := []byte{0x01, 0x01, 0x01, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 2)
+
+	r.SkipNBytes(3)
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipNBytesEOF(t *testing.T) {
+	data := []byte{0x01, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 2)
+
+	r.SkipNBytes(3)
+
+	assert.Error(t, r.Error)
+}
+
+func TestReader_SkipBool(t *testing.T) {
+	data := []byte{0x01, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipBool()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipInt(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "Skipped",
+			data: []byte{0x38, 0x36},
+		},
+		{
+
+			name: "Overflow",
+			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0xAD, 0x36},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			r := avro.NewReader(bytes.NewReader(test.data), 10)
+
+			r.SkipInt()
+
+			require.NoError(t, r.Error)
+			assert.Equal(t, int32(27), r.ReadInt())
+		})
+	}
+}
+
+func TestReader_SkipLong(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "Skipped",
+			data: []byte{0x38, 0x36},
+		},
+		{
+
+			name: "Overflow",
+			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0xAD, 0xAD, 0xE2, 0xA2, 0xF3, 0xAD, 0x36},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			r := avro.NewReader(bytes.NewReader(test.data), 10)
+
+			r.SkipLong()
+
+			require.NoError(t, r.Error)
+			assert.Equal(t, int32(27), r.ReadInt())
+		})
+	}
+}
+
+func TestReader_SkipFloat(t *testing.T) {
+	data := []byte{0x00, 0x00, 0x00, 0x00, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipFloat()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipDouble(t *testing.T) {
+	data := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipDouble()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipString(t *testing.T) {
+	data := []byte{0x06, 0x66, 0x6F, 0x6F, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipString()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipStringEmpty(t *testing.T) {
+	data := []byte{0x00, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipString()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipBytes(t *testing.T) {
+	data := []byte{0x06, 0x66, 0x6F, 0x6F, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipBytes()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
+func TestReader_SkipBytesEmpty(t *testing.T) {
+	data := []byte{0x00, 0x36}
+	r := avro.NewReader(bytes.NewReader(data), 10)
+
+	r.SkipBytes()
+
+	require.NoError(t, r.Error)
+	assert.Equal(t, int32(27), r.ReadInt())
+}
+
 func TestReader_SkipTo(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/reader_skip_test.go
+++ b/reader_skip_test.go
@@ -9,147 +9,77 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReader_SkipNBytes(t *testing.T) {
-	data := []byte{0x01, 0x01, 0x01, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 2)
-
-	r.SkipNBytes(3)
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipNBytesEOF(t *testing.T) {
-	data := []byte{0x01, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 2)
-
-	r.SkipNBytes(3)
-
-	assert.Error(t, r.Error)
-}
-
-func TestReader_SkipBool(t *testing.T) {
-	data := []byte{0x01, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipBool()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipInt(t *testing.T) {
+func TestReader_SkipTo(t *testing.T) {
 	tests := []struct {
-		name string
-		data []byte
+		name        string
+		data        []byte
+		bufSize     int
+		token       []byte
+		wantSkipped int
+		wantErr     require.ErrorAssertionFunc
 	}{
+		// TokenInFirstBuffer
 		{
-			name: "Skipped",
-			data: []byte{0x38, 0x36},
+			name:        "TokenInFirstBuffer",
+			data:        []byte("abcdefgTOKENhij"),
+			bufSize:     1024,
+			token:       []byte("TOKEN"),
+			wantSkipped: 12, // "abcdefgTOKEN" length
+			wantErr:     require.NoError,
+		},
+		// TokenSplitAcrossBuffers
+		{
+			name:        "TokenSplitAcrossBuffers",
+			data:        append(append(make([]byte, 10), []byte("TO")...), []byte("KEN")...),
+			bufSize:     12, // 10 filler + "TO" = 12 bytes. Split happens exactly after "TO".
+			token:       []byte("TOKEN"),
+			wantSkipped: 15, // 10 filler + TOKEN
+			wantErr:     require.NoError,
+		},
+		// FalsePositiveSplit: XXKEN should NOT match TOKEN
+		{
+			name:        "FalsePositiveSplit",
+			data:        []byte("XXKEN"),
+			bufSize:     2, // Split "XX", "KEN"
+			token:       []byte("TOKEN"),
+			wantSkipped: 0,
+			wantErr:     require.Error, // Should fail to find TOKEN
+		},
+		// TokenNotFound
+		{
+			name:        "TokenNotFound",
+			data:        []byte("abcdefg"),
+			bufSize:     1024,
+			token:       []byte("XYZ"),
+			wantSkipped: 7,
+			wantErr:     require.Error, // EOF causes error in SkipTo
 		},
 		{
-			name: "Overflow",
-			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0xAD, 0x36},
+			name:        "EmptyToken",
+			data:        []byte("abc"),
+			bufSize:     1024,
+			token:       []byte{},
+			wantSkipped: 0,
+			wantErr:     require.NoError,
+		},
+		{
+			name:        "PartialMatchAtEndButNotComplete",
+			data:        []byte("abcTO"),
+			bufSize:     10,
+			token:       []byte("TOKEN"),
+			wantSkipped: 5,
+			wantErr:     require.Error,
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			r := avro.NewReader(bytes.NewReader(test.data), 10)
-
-			r.SkipInt()
-
-			require.NoError(t, r.Error)
-			assert.Equal(t, int32(27), r.ReadInt())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := avro.NewReader(bytes.NewReader(tt.data), tt.bufSize)
+			skipped, err := r.SkipTo(tt.token)
+			tt.wantErr(t, err)
+			if err == nil {
+				assert.Equal(t, tt.wantSkipped, skipped)
+			}
 		})
 	}
-}
-
-func TestReader_SkipLong(t *testing.T) {
-	tests := []struct {
-		name string
-		data []byte
-	}{
-		{
-			name: "Skipped",
-			data: []byte{0x38, 0x36},
-		},
-		{
-			name: "Overflow",
-			data: []byte{0xE2, 0xA2, 0xF3, 0xAD, 0xAD, 0xAD, 0xE2, 0xA2, 0xF3, 0xAD, 0x36},
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			r := avro.NewReader(bytes.NewReader(test.data), 10)
-
-			r.SkipLong()
-
-			require.NoError(t, r.Error)
-			assert.Equal(t, int32(27), r.ReadInt())
-		})
-	}
-}
-
-func TestReader_SkipFloat(t *testing.T) {
-	data := []byte{0x00, 0x00, 0x00, 0x00, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipFloat()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipDouble(t *testing.T) {
-	data := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipDouble()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipString(t *testing.T) {
-	data := []byte{0x06, 0x66, 0x6F, 0x6F, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipString()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipStringEmpty(t *testing.T) {
-	data := []byte{0x00, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipString()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipBytes(t *testing.T) {
-	data := []byte{0x06, 0x66, 0x6F, 0x6F, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipBytes()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
-}
-
-func TestReader_SkipBytesEmpty(t *testing.T) {
-	data := []byte{0x00, 0x36}
-	r := avro.NewReader(bytes.NewReader(data), 10)
-
-	r.SkipBytes()
-
-	require.NoError(t, r.Error)
-	assert.Equal(t, int32(27), r.ReadInt())
 }


### PR DESCRIPTION
## Goal of this PR

# Expose Reader Offset and OCF Block Status for Concurrent Decoder

## Description
This PR enhances the `Reader` and `OCF Decoder` by exposing internal state information that is critical for advanced processing scenarios, such as progress tracking, concurrently splitting, and debugging.

### Key Changes
- **`Reader.InputOffset()`**: Adds a method to the `Reader` to retrieve the current input offset. This allows consumers to know exactly where in the underlying stream the reader is currently positioned.
- **`OCF Decoder.BlockStatus()`**: Introduces a `BlockStatus()` method (and corresponding struct) to the OCF Decoder. This provides a snapshot of the current block being processed, including:
    - `Current`: The index of the current record within the block.
    - `Count`: The total number of records in the current block.
    - `Size`: The size (in bytes) of the current block.
    - `Offset`: The input offset provided by the underlying reader.

## Motivation
Currently, the `avro` package abstracts away the underlying stream position and block details. While this is fine for simple reading, it limits users who need to:
1.  **Track Progress**: Accurately report percentage completion when processing large OCF files.
2.  **Implement Splitting**: effectively split file processing based on block boundaries and offsets.
3.  **Debug**: gain better visibility into how the decoder is traversing the file structure.

## Use Case Example
A data processing pipeline can now use `BlockStatus()` to log precise progress or checkpoint processing at specific block offsets, improving reliability and observability.

```go
// Example usage
decoder, _ := ocf.NewDecoder(r)
for decoder.HasNext() {
    var record MyRecord
    decoder.Decode(&record)
    
    // Track progress
    status := decoder.BlockStatus()
    fmt.Printf("Processing record %d/%d of block at offset %d\n", status.Current, status.Count, status.Offset)
}

## How did I test it?

I Make a test TestConcurrentDecode for concurrent decode

Please, let me know if this PR makes sense for you.
