### PR TITLE
feat(encoder): add UTF-8 validation in map encoder and boundary checks in native encoder

### DIFF
--- a/codec_native.go
+++ b/codec_native.go
@@ -371,7 +371,15 @@ func (*intCodec[T]) Decode(ptr unsafe.Pointer, r *Reader) {
 }
 
 func (*intCodec[T]) Encode(ptr unsafe.Pointer, w *Writer) {
-	w.WriteInt(int32(*((*T)(ptr))))
+	val := *(*T)(ptr)
+	i32 := int32(val)
+
+	if T(i32) != val {
+		w.Error = fmt.Errorf("avro: value %v overflows Avro int", val)
+		return
+	}
+
+	w.WriteInt(i32)
 }
 
 type largeInt interface {

--- a/encoder_native_test.go
+++ b/encoder_native_test.go
@@ -2,6 +2,7 @@ package avro_test
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -63,6 +64,24 @@ func TestEncoder_Int(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0x36}, buf.Bytes())
+}
+
+func TestEncoder_IntBoundaries(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `int`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	require.NoError(t, enc.Encode(uint8(math.MaxUint8)))
+	require.NoError(t, enc.Encode(uint16(math.MaxUint16)))
+	require.NoError(t, enc.Encode(int32(math.MaxInt32)))
+	require.NoError(t, enc.Encode(int32(math.MinInt32)))
+	require.NoError(t, enc.Encode(int(math.MaxInt32)))
+
+	assert.ErrorContains(t, enc.Encode(math.MaxInt32+1), "overflows Avro int")
+	assert.ErrorContains(t, enc.Encode(math.MinInt32-1), "overflows Avro int")
 }
 
 func TestEncoder_IntInvalidSchema(t *testing.T) {
@@ -280,6 +299,21 @@ func TestEncoder_Int64FromInt(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0x80, 0x80, 0x80, 0x80, 0x10}, buf.Bytes())
+}
+
+func TestEncoder_LongBoundaries(t *testing.T) {
+	defer ConfigTeardown()
+
+	schema := `long`
+	buf := bytes.NewBuffer([]byte{})
+	enc, err := avro.NewEncoder(schema, buf)
+	require.NoError(t, err)
+
+	require.NoError(t, enc.Encode(int(math.MaxInt)))
+	require.NoError(t, enc.Encode(int(math.MinInt)))
+	require.NoError(t, enc.Encode(int64(math.MaxInt64)))
+	require.NoError(t, enc.Encode(int64(math.MinInt64)))
+	require.NoError(t, enc.Encode(uint32(math.MaxUint32)))
 }
 
 func TestEncoder_Int64InvalidSchema(t *testing.T) {


### PR DESCRIPTION
## Goal of this PR

This PR ensures that Avro map keys are validated as UTF-8 strings before being written during encoding, in accordance with the Avro specification.

Previously, map keys were written to the output stream before UTF-8 validation, which could allow invalid keys to be encoded and result in malformed Avro payloads. This change updates both `mapEncoder` and `mapEncoderMarshaller` to:

* Extract the key as a Go `string`

* Validate UTF-8 correctness upfront

* Write the key only after successful validation

Invalid UTF-8 keys now result in a clear, early error rather than corrupt output.

A similar change is also done in `codec.go` to check for `int` overflow.

## How did I test it?

Test cases have been added for this change, along with other test cases to check for overflows.
